### PR TITLE
fix table rows benchmark

### DIFF
--- a/benchmarks/suites/appendManyRowsToLargeTable.tsx
+++ b/benchmarks/suites/appendManyRowsToLargeTable.tsx
@@ -19,7 +19,7 @@ import {
 import { buildData, patch } from '../data';
 
 const data = buildData(10000);
-const createVNode = () => (
+const createVNode = (data) => (
   <table>
     {data.map(({ id, label }) => (
       <tr key={String(id)}>
@@ -29,10 +29,10 @@ const createVNode = () => (
     ))}
   </table>
 );
-const oldVNode = createVNode();
+const oldVNode = createVNode(data);
+const vnode = createVNode([...data, ...buildData(1000)]);
+
 const el = () => createElement(oldVNode);
-const vnode = createVNode();
-data.push(...buildData(1000));
 
 const suite = Suite('append many rows to large table (appending 1,000 to a table of 10,000 rows)', {
   million: () => {


### PR DESCRIPTION
The `appendManyRowsToLargeTable` benchmark is not actually measuring what it's supposed to.

https://github.com/aidenybai/million/blob/8fbd1edad6f521dcc0863f08748c4f9b02720f45/benchmarks/suites/appendManyRowsToLargeTable.tsx#L32-L35

Note how the `vnode` is created before the extra 1000 elements are pushed.

This means the patch is a no-op for all the benchmarks, except the DOM one. This can be verified by checking the old and new `el.children.length` in the benchmark code (10000, 10000).

The obvious fix is to move `data.push(...)` one line above so that `vnode` is created with 11k elements, but I preferred to make it more explicit.

Unfortunately this means the DOM is actually 2x faster than _million_. It makes sense though, since it cannot possibly be doing less work, unless some sort of smart pool for cloning elements was used that could outperform the DOM, which doesn't seem to be the case.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
  - [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
