### PR TITLE
fix(createElement): ignore prop value with null and undefined

### DIFF
--- a/src/million/createElement.ts
+++ b/src/million/createElement.ts
@@ -24,15 +24,17 @@ export const createElement = (vnode?: VNode | null, attachField = true): DOMNode
         } else if (propName.startsWith('xlink')) {
           el.setAttributeNS(XLINK_NS, 'href', String(propValue));
         }
-      } else if (
-        el[propName] !== undefined &&
-        el[propName] !== null &&
-        !(el instanceof SVGElement) &&
-        propName in el
-      ) {
-        el[propName] = propValue;
-      } else {
-        el.setAttribute(propName, String(propValue));
+      } else if (propValue !== undefined && propValue !== null) {
+        if (
+          el[propName] !== undefined &&
+          el[propName] !== null &&
+          !(el instanceof SVGElement) &&
+          propName in el
+        ) {
+          el[propName] = propValue;
+        } else {
+          el.setAttribute(propName, String(propValue));
+        }
       }
     }
   }

--- a/test/createElement.test.ts
+++ b/test/createElement.test.ts
@@ -58,4 +58,12 @@ describe.concurrent('createElement', () => {
     const el = document.createComment('');
     expectEqualNode(createElement(null), el);
   });
+
+  it('should not set prop value with null and undefined', () => {
+    const el = document.createElement('div');
+    el.id = '0';
+    el.setAttribute('bar', 'false');
+    el.appendChild(document.createTextNode('foo'));
+    expectEqualNode(createElement(m('div', { id: 0, children: undefined, foo: null, bar: false }, ['foo'])), el);
+  });
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

I am using JSX with babel automatic runtime transformation and got `Uncaught TypeError: setting getter-only property "children"`. It is caused by `jsx` function that set `props.children` to `undefined`:

https://github.com/aidenybai/million/blob/e0896e69ecbed516c7e2c77dbe8c0fe7fca0a32e/src/jsx-runtime/jsx.ts#L12

However, `createElement` will always set prop (including `children`) even if the prop is read-only and the prop value is `undefined`. The PR adds an additional `null` and `undefined` check before applying props. The corresponding test case has also been added as well.