### PR TITLE
feat: should not use svg twice.

### DIFF
--- a/src/jsx-runtime/h.ts
+++ b/src/jsx-runtime/h.ts
@@ -123,6 +123,5 @@ export function h(
     }
   }
 
-  const vnode = m(tag, props, normalizedChildren, flag, delta, hook);
-  return tag === 'svg' ? svg(vnode) : vnode;
+  return m(tag, props, normalizedChildren, flag, delta, hook);
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
[here](https://github.com/aidenybai/million/blob/main/src/million/m.ts#L107), so in `h` function should not use `svg` again.

is there anything i missing?
**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
