### PR TITLE
fix: the augmentor function is named hook

### DIFF
--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -45,7 +45,7 @@ export const hook = (fn) => {
 export const contextual = (fn) => {
   let check = true;
   let context = null;
-  const augmented = augmentor(function () {
+  const augmented = hook(function () {
     return fn.apply(context, arguments);
   });
   return function hook() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
the `augmentor` function is named `hook`
**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
