### PR TITLE
fix: `welcome` command not working on initial run

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "bumpp": "^8.2.1",
     "c8": "^7.12.0",
     "esbuild": "^0.14.51",
-    "eslint": "^8.20.0",
+    "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.5.0",
     "export-size": "^0.5.2",
     "fsxx": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       bumpp: ^8.2.1
       c8: ^7.12.0
       esbuild: ^0.14.51
-      eslint: ^8.20.0
+      eslint: ^8.21.0
       eslint-config-prettier: ^8.5.0
       export-size: ^0.5.2
       fsxx: ^0.1.0
@@ -36,14 +36,14 @@ importers:
     devDependencies:
       '@babel/core': 7.18.9
       '@types/node': 18.6.3
-      '@typescript-eslint/eslint-plugin': 5.31.0_d5zwcxr4bwkhmuo464cb3a2puu
-      '@typescript-eslint/parser': 5.31.0_he2ccbldppg44uulnyq4rwocfa
-      '@vercel/style-guide': 3.0.0_r2fvqfuoeydpw3g73cntftn3ju
+      '@typescript-eslint/eslint-plugin': 5.31.0_jnss7dz76sznncvpyatba5hbxa
+      '@typescript-eslint/parser': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
+      '@vercel/style-guide': 3.0.0_wy64vqcxp2lgizwq2344pbzmei
       bumpp: 8.2.1
       c8: 7.12.0
       esbuild: 0.14.51
-      eslint: 8.20.0
-      eslint-config-prettier: 8.5.0_eslint@8.20.0
+      eslint: 8.21.0
+      eslint-config-prettier: 8.5.0_eslint@8.21.0
       export-size: 0.5.2
       fsxx: 0.1.0
       husky: 8.0.1
@@ -218,7 +218,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.17.0_454u7sltq2wfyzqnoclqps3oeu:
+  /@babel/eslint-parser/7.17.0_qixkf6blpy7m2ag6xkq37oeusq:
     resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -226,7 +226,7 @@ packages:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
       '@babel/core': 7.18.9
-      eslint: 8.20.0
+      eslint: 8.21.0
       eslint-scope: 5.1.1
       eslint-visitor-keys: 2.1.0
       semver: 6.3.0
@@ -421,7 +421,7 @@ packages:
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.3.2
+      espree: 9.3.3
       globals: 13.17.0
       ignore: 5.2.0
       import-fresh: 3.3.0
@@ -455,8 +455,8 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@humanwhocodes/config-array/0.9.5:
-    resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
+  /@humanwhocodes/config-array/0.10.4:
+    resolution: {integrity: sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -464,6 +464,10 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@humanwhocodes/gitignore-to-minimatch/1.0.2:
+    resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
     dev: true
 
   /@humanwhocodes/object-schema/1.2.1:
@@ -1267,7 +1271,7 @@ packages:
     resolution: {integrity: sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.17.0_454dk6yznz3m7sws7azg6fs7re:
+  /@typescript-eslint/eslint-plugin/5.17.0_dog4hmxv4hrcw6vj4qw2his6ka:
     resolution: {integrity: sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1278,12 +1282,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/parser': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
       '@typescript-eslint/scope-manager': 5.17.0
-      '@typescript-eslint/type-utils': 5.17.0_he2ccbldppg44uulnyq4rwocfa
-      '@typescript-eslint/utils': 5.17.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/type-utils': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
+      '@typescript-eslint/utils': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
       debug: 4.3.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
@@ -1294,7 +1298,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.31.0_d5zwcxr4bwkhmuo464cb3a2puu:
+  /@typescript-eslint/eslint-plugin/5.31.0_jnss7dz76sznncvpyatba5hbxa:
     resolution: {integrity: sha512-VKW4JPHzG5yhYQrQ1AzXgVgX8ZAJEvCz0QI6mLRX4tf7rnFfh5D8SKm0Pq6w5PyNfAWJk6sv313+nEt3ohWMBQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1305,12 +1309,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.31.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/parser': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
       '@typescript-eslint/scope-manager': 5.31.0
-      '@typescript-eslint/type-utils': 5.31.0_he2ccbldppg44uulnyq4rwocfa
-      '@typescript-eslint/utils': 5.31.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/type-utils': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
+      '@typescript-eslint/utils': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
       debug: 4.3.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
@@ -1321,7 +1325,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.17.0_he2ccbldppg44uulnyq4rwocfa:
+  /@typescript-eslint/parser/5.17.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1335,13 +1339,13 @@ packages:
       '@typescript-eslint/types': 5.17.0
       '@typescript-eslint/typescript-estree': 5.17.0_typescript@4.7.4
       debug: 4.3.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.31.0_he2ccbldppg44uulnyq4rwocfa:
+  /@typescript-eslint/parser/5.31.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-UStjQiZ9OFTFReTrN+iGrC6O/ko9LVDhreEK5S3edmXgR396JGq7CoX2TWIptqt/ESzU2iRKXAHfSF2WJFcWHw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1355,7 +1359,7 @@ packages:
       '@typescript-eslint/types': 5.31.0
       '@typescript-eslint/typescript-estree': 5.31.0_typescript@4.7.4
       debug: 4.3.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -1377,7 +1381,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.31.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.17.0_he2ccbldppg44uulnyq4rwocfa:
+  /@typescript-eslint/type-utils/5.17.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1387,16 +1391,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.17.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/utils': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
       debug: 4.3.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.31.0_he2ccbldppg44uulnyq4rwocfa:
+  /@typescript-eslint/type-utils/5.31.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-7ZYqFbvEvYXFn9ax02GsPcEOmuWNg+14HIf4q+oUuLnMbpJ6eHAivCg7tZMVwzrIuzX3QCeAOqKoyMZCv5xe+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1406,9 +1410,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.31.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/utils': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
       debug: 4.3.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -1467,7 +1471,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.17.0_he2ccbldppg44uulnyq4rwocfa:
+  /@typescript-eslint/utils/5.17.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1477,15 +1481,15 @@ packages:
       '@typescript-eslint/scope-manager': 5.17.0
       '@typescript-eslint/types': 5.17.0
       '@typescript-eslint/typescript-estree': 5.17.0_typescript@4.7.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.20.0
+      eslint-utils: 3.0.0_eslint@8.21.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.31.0_he2ccbldppg44uulnyq4rwocfa:
+  /@typescript-eslint/utils/5.31.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1495,9 +1499,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.31.0
       '@typescript-eslint/types': 5.31.0
       '@typescript-eslint/typescript-estree': 5.31.0_typescript@4.7.4
-      eslint: 8.20.0
+      eslint: 8.21.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.20.0
+      eslint-utils: 3.0.0_eslint@8.21.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -1519,30 +1523,30 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@vercel/style-guide/3.0.0_r2fvqfuoeydpw3g73cntftn3ju:
+  /@vercel/style-guide/3.0.0_wy64vqcxp2lgizwq2344pbzmei:
     resolution: {integrity: sha512-4hAlUpXrgty3eWOmYuVMjMxhsYaw0wFZAgFNlsrwp5LM6iPcjZXKbhEi3z3QZIJ7Mkixtg0gpYfq9oNzZgEahA==}
     peerDependencies:
       eslint: ^8.12.0
       prettier: ^2.6.1
     dependencies:
-      '@babel/eslint-parser': 7.17.0_454u7sltq2wfyzqnoclqps3oeu
+      '@babel/eslint-parser': 7.17.0_qixkf6blpy7m2ag6xkq37oeusq
       '@next/eslint-plugin-next': 12.1.2
       '@rushstack/eslint-patch': 1.1.1
-      '@typescript-eslint/eslint-plugin': 5.17.0_454dk6yznz3m7sws7azg6fs7re
-      '@typescript-eslint/parser': 5.17.0_he2ccbldppg44uulnyq4rwocfa
-      eslint: 8.20.0
-      eslint-config-prettier: 8.5.0_eslint@8.20.0
+      '@typescript-eslint/eslint-plugin': 5.17.0_dog4hmxv4hrcw6vj4qw2his6ka
+      '@typescript-eslint/parser': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
+      eslint: 8.21.0
+      eslint-config-prettier: 8.5.0_eslint@8.21.0
       eslint-import-resolver-alias: 1.1.2_t6pef3jrjg2rjejjp7kevcbc34
-      eslint-import-resolver-typescript: 2.7.0_54w6onclsgshjl66pd6lvxh5h4
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.20.0
-      eslint-plugin-import: 2.25.4_6m6exhyykwsab4m53rm3wxoeo4
-      eslint-plugin-jest: 26.1.3_t2wdw5a5ybsvpehug3ozvzhm7m
-      eslint-plugin-jsx-a11y: 6.5.1_eslint@8.20.0
-      eslint-plugin-react: 7.29.4_eslint@8.20.0
-      eslint-plugin-react-hooks: 4.3.0_eslint@8.20.0
-      eslint-plugin-testing-library: 5.1.0_he2ccbldppg44uulnyq4rwocfa
+      eslint-import-resolver-typescript: 2.7.0_qdud4gbna7fhnhcxlvvbwlh2gy
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.21.0
+      eslint-plugin-import: 2.25.4_trh7hixcmw4armvsbp2c77dar4
+      eslint-plugin-jest: 26.1.3_iytnyp7ztatrocensi6ie2cnxu
+      eslint-plugin-jsx-a11y: 6.5.1_eslint@8.21.0
+      eslint-plugin-react: 7.29.4_eslint@8.21.0
+      eslint-plugin-react-hooks: 4.3.0_eslint@8.21.0
+      eslint-plugin-testing-library: 5.1.0_qugx7qdu5zevzvxaiqyxfiwquq
       eslint-plugin-tsdoc: 0.2.14
-      eslint-plugin-unicorn: 41.0.1_eslint@8.20.0
+      eslint-plugin-unicorn: 41.0.1_eslint@8.21.0
       prettier: 2.7.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -3338,13 +3342,13 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier/8.5.0_eslint@8.20.0:
+  /eslint-config-prettier/8.5.0_eslint@8.21.0:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.20.0
+      eslint: 8.21.0
     dev: true
 
   /eslint-import-resolver-alias/1.1.2_t6pef3jrjg2rjejjp7kevcbc34:
@@ -3353,7 +3357,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.25.4_6m6exhyykwsab4m53rm3wxoeo4
+      eslint-plugin-import: 2.25.4_trh7hixcmw4armvsbp2c77dar4
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -3365,7 +3369,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/2.7.0_54w6onclsgshjl66pd6lvxh5h4:
+  /eslint-import-resolver-typescript/2.7.0_qdud4gbna7fhnhcxlvvbwlh2gy:
     resolution: {integrity: sha512-MNHS3u5pebvROX4MjGP9coda589ZGfL1SqdxUV4kSrcclfDRWvNE2D+eljbnWVMvWDVRgT89nhscMHPKYGcObQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3373,8 +3377,8 @@ packages:
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4
-      eslint: 8.20.0
-      eslint-plugin-import: 2.25.4_6m6exhyykwsab4m53rm3wxoeo4
+      eslint: 8.21.0
+      eslint-plugin-import: 2.25.4_trh7hixcmw4armvsbp2c77dar4
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.1
@@ -3401,27 +3405,27 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/parser': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.0_54w6onclsgshjl66pd6lvxh5h4
+      eslint-import-resolver-typescript: 2.7.0_qdud4gbna7fhnhcxlvvbwlh2gy
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-eslint-comments/3.2.0_eslint@8.20.0:
+  /eslint-plugin-eslint-comments/3.2.0_eslint@8.21.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
       escape-string-regexp: 1.0.5
-      eslint: 8.20.0
+      eslint: 8.21.0
       ignore: 5.2.0
     dev: true
 
-  /eslint-plugin-import/2.25.4_6m6exhyykwsab4m53rm3wxoeo4:
+  /eslint-plugin-import/2.25.4_trh7hixcmw4armvsbp2c77dar4:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3431,12 +3435,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0_he2ccbldppg44uulnyq4rwocfa
+      '@typescript-eslint/parser': 5.17.0_qugx7qdu5zevzvxaiqyxfiwquq
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.20.0
+      eslint: 8.21.0
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.3_xe6opc42dcdurrfqfbzzc3a6si
       has: 1.0.3
@@ -3452,7 +3456,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/26.1.3_t2wdw5a5ybsvpehug3ozvzhm7m:
+  /eslint-plugin-jest/26.1.3_iytnyp7ztatrocensi6ie2cnxu:
     resolution: {integrity: sha512-Pju+T7MFpo5VFhFlwrkK/9jRUu18r2iugvgyrWOnnGRaVTFFmFXp+xFJpHyqmjjLmGJPKLeEFLVTAxezkApcpQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3465,15 +3469,15 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.17.0_454dk6yznz3m7sws7azg6fs7re
-      '@typescript-eslint/utils': 5.31.0_he2ccbldppg44uulnyq4rwocfa
-      eslint: 8.20.0
+      '@typescript-eslint/eslint-plugin': 5.17.0_dog4hmxv4hrcw6vj4qw2his6ka
+      '@typescript-eslint/utils': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
+      eslint: 8.21.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.5.1_eslint@8.20.0:
+  /eslint-plugin-jsx-a11y/6.5.1_eslint@8.21.0:
     resolution: {integrity: sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -3487,23 +3491,23 @@ packages:
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.20.0
+      eslint: 8.21.0
       has: 1.0.3
       jsx-ast-utils: 3.3.2
       language-tags: 1.0.5
       minimatch: 3.1.2
     dev: true
 
-  /eslint-plugin-react-hooks/4.3.0_eslint@8.20.0:
+  /eslint-plugin-react-hooks/4.3.0_eslint@8.21.0:
     resolution: {integrity: sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.20.0
+      eslint: 8.21.0
     dev: true
 
-  /eslint-plugin-react/7.29.4_eslint@8.20.0:
+  /eslint-plugin-react/7.29.4_eslint@8.21.0:
     resolution: {integrity: sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3512,7 +3516,7 @@ packages:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
       doctrine: 2.1.0
-      eslint: 8.20.0
+      eslint: 8.21.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.2
       minimatch: 3.1.2
@@ -3526,14 +3530,14 @@ packages:
       string.prototype.matchall: 4.0.7
     dev: true
 
-  /eslint-plugin-testing-library/5.1.0_he2ccbldppg44uulnyq4rwocfa:
+  /eslint-plugin-testing-library/5.1.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-YSNzasJUbyhOTe14ZPygeOBvcPvcaNkwHwrj4vdf+uirr2D32JTDaKi6CP5Os2aWtOcvt4uBSPXp9h5xGoqvWQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.31.0_he2ccbldppg44uulnyq4rwocfa
-      eslint: 8.20.0
+      '@typescript-eslint/utils': 5.31.0_qugx7qdu5zevzvxaiqyxfiwquq
+      eslint: 8.21.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3546,7 +3550,7 @@ packages:
       '@microsoft/tsdoc-config': 0.15.2
     dev: true
 
-  /eslint-plugin-unicorn/41.0.1_eslint@8.20.0:
+  /eslint-plugin-unicorn/41.0.1_eslint@8.21.0:
     resolution: {integrity: sha512-gF5vo2dIj0YdNMQ/IMegiBkQdQ22GBFFVpdkJP+0og3w7XD4ypea0xQVRv6iofkLVR2w0phAdikcnU01ybd4Ow==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -3555,8 +3559,8 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       ci-info: 3.3.2
       clean-regexp: 1.0.0
-      eslint: 8.20.0
-      eslint-utils: 3.0.0_eslint@8.20.0
+      eslint: 8.21.0
+      eslint-utils: 3.0.0_eslint@8.21.0
       esquery: 1.4.0
       indent-string: 4.0.0
       is-builtin-module: 3.1.0
@@ -3585,13 +3589,13 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.20.0:
+  /eslint-utils/3.0.0_eslint@8.21.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.20.0
+      eslint: 8.21.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -3605,13 +3609,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.20.0:
-    resolution: {integrity: sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==}
+  /eslint/8.21.0:
+    resolution: {integrity: sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
       '@eslint/eslintrc': 1.3.0
-      '@humanwhocodes/config-array': 0.9.5
+      '@humanwhocodes/config-array': 0.10.4
+      '@humanwhocodes/gitignore-to-minimatch': 1.0.2
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
@@ -3619,16 +3624,19 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.20.0
+      eslint-utils: 3.0.0_eslint@8.21.0
       eslint-visitor-keys: 3.3.0
-      espree: 9.3.2
+      espree: 9.3.3
       esquery: 1.4.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
+      find-up: 5.0.0
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
       globals: 13.17.0
+      globby: 11.1.0
+      grapheme-splitter: 1.0.4
       ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -3649,8 +3657,8 @@ packages:
       - supports-color
     dev: true
 
-  /espree/9.3.2:
-    resolution: {integrity: sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==}
+  /espree/9.3.3:
+    resolution: {integrity: sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.0
@@ -4275,6 +4283,10 @@ packages:
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: true
+
+  /grapheme-splitter/1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
   /gray-matter/4.0.3:

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,7 +3,15 @@ import { write, exists } from 'fsxx';
 import { info } from './helpers.mjs';
 
 const index_html = `<!DOCTYPE html><html><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><link rel="stylesheet" href="./style.css"><script type="module" src="./script.tsx"></script></head><body><div id="root"></div></body></html>`;
-const script_tsx = ``;
+const script_tsx = `import { createRoot, useState } from 'packages/react'; // You can import anything under packages/ here (ex. 'packages/million')
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+
+createRoot(document.getElementById('root')!).render(<App />);`;
 const style_css = `body { font-size: 2em; display: flex; justify-content: center; align-items: start; padding-top: 2em; font-family: Arial; }`;
 
 if (!(await exists('dev'))) {

--- a/scripts/welcome.mjs
+++ b/scripts/welcome.mjs
@@ -37,19 +37,6 @@ await send(chalk.bold(chalk.gray('$ pnpm run dev')), 3000);
 console.log();
 $`pnpm run dev`;
 
-await fs.writeFile(
-  path.join(__dirname, '../dev/script.tsx'),
-  `import { createRoot, useState } from 'packages/react'; // You can import anything under packages/ here (ex. 'packages/million')
-
-function App() {
-  const [count, setCount] = useState(0);
-
-  return <button onClick={() => setCount(count + 1)}>{count}</button>;
-}
-
-createRoot(document.getElementById('root')!).render(<App />);`,
-);
-
 await send(
   `A new tab should have opened! Try editing ${chalk.gray(
     '`dev/script.tsx`',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When running the `welcome` script for the first time, I've noticed that the command fails with the following error:

<img width="1089" alt="Screenshot 2022-08-01 at 10 21 23" src="https://user-images.githubusercontent.com/43268759/182106870-25c0cb0b-f9ba-4a4f-a2fb-acf3f7519c71.png">

Digging a bit into it, I found that `dev/script.tsx` does not exist because the `pnpm run dev` command is not awaited - but I understand why it's not because the command runs `vite` and such never ends unless we exit the process.

So I've moved the file writing to `dev/script.tsx` from the `welcome` script to the `dev` one. For reference, this error was thrown only if we don't have the `dev/script.tsx` file - so only on the initial run of this command (= if we don't have the `dev` folder).

Also, not really sure if it's intentional to update the dependencies when committing (ESLint has been bumped to 8.21.0, tell me if I need to revert this)

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
