### PR TITLE
Fix: small typo

### DIFF
--- a/website/pages/docs/react/use-list.mdx
+++ b/website/pages/docs/react/use-list.mdx
@@ -9,7 +9,7 @@ import Link from 'next/link';
 **Syntax:** `const [list, delta] = useList(initialListValue)`\
 **Example:** `const [list, delta] = useList([1, 2, 3])`
 
-The `useList()` hook is an optimized version of the `useState()` hook, but exclusvely for arrays. Instead of returning `state` and `setState`, it returns `list` and `delta`. `list` is a mutable value that you can update like a variable, and `delta` is a payload that you can pass into virtual nodes.
+The `useList()` hook is an optimized version of the `useState()` hook, but exclusively for arrays. Instead of returning `state` and `setState`, it returns `list` and `delta`. `list` is a mutable value that you can update like a variable, and `delta` is a payload that you can pass into virtual nodes.
 
 ```js {4,10,15}
 import { createRoot, useList } from 'million/react';


### PR DESCRIPTION
Small typo in the docs

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
