### PR TITLE
Fix CarbonAd overlay issue on mobile

### DIFF
--- a/benchmarks/style.css
+++ b/benchmarks/style.css
@@ -62,6 +62,7 @@ details {
 #carbonads {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
     'Helvetica Neue', Helvetica, Arial, sans-serif;
+  z-index: 0;
 }
 #carbonads {
   display: flex;

--- a/benchmarks/style.css
+++ b/benchmarks/style.css
@@ -62,7 +62,7 @@ details {
 #carbonads {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
     'Helvetica Neue', Helvetica, Arial, sans-serif;
-  z-index: 0;
+  z-index: 0 !important; /* !important, so it overrites CarbonAd default setting to have a z-index of 100 */
 }
 #carbonads {
   display: flex;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed #256. Originally the CarbonAd on mobile would go over the mobile nav dropdown. Now it is fixed and the carbonAd element now has a set z-index of 0.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
