### PR TITLE
docs: rename ELEMENT_SKIP_DIFF to ELEMENT_FORCE_UPDATE

### DIFF
--- a/website/pages/docs/api/advanced/flags.mdx
+++ b/website/pages/docs/api/advanced/flags.mdx
@@ -38,21 +38,21 @@ const vnode = m('div', _, ['Please ignore me'], Flags.ELEMENT_IGNORE);
 }
 ```
 
-## `Flags.ELEMENT_SKIP_DIFF`
+## `Flags.ELEMENT_FORCE_UPDATE`
 
 If you need to add group functionality, using this flag allows you to skip diffing entirely and hard replace a VNode.
 
 ```js
 import { _, m, Flags } from 'million';
 
-const vnode = m('div', _, ['Please hard replace me'], Flags.ELEMENT_SKIP_DIFF);
+const vnode = m('div', _, ['Please hard replace me'], Flags.ELEMENT_FORCE_UPDATE);
 ```
 
 ```js {4}
 {
   tag: 'div',
   children: ['Please hard replace me'],
-  flag: /* Flags.ELEMENT_SKIP_DIFF */,
+  flag: /* Flags.ELEMENT_FORCE_UPDATE */,
 }
 ```
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Updates the wording & examples in the "Flags" section ([ref](https://millionjs.org/docs/api/advanced/flags)) of the docs to reflect the available Flags options.

Please let me know if I am incorrect on my understanding that `Flags.ELEMENT_SKIP_DIFF` and `Flags.ELEMENT_FORCE_UPDATE` were intended to have the same functionality.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
