### PR TITLE
refactor: add useDarkMode hook and cleanups

### DIFF
--- a/website/components/chart.tsx
+++ b/website/components/chart.tsx
@@ -8,8 +8,8 @@ import {
   Title,
   Tooltip,
 } from 'chart.js';
-import { useEffect, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
+import { useDarkMode } from './useDarkMode';
 
 ChartJS.register(
   CategoryScale,
@@ -47,35 +47,17 @@ const options = {
 };
 
 export function Chart() {
-  const [darkMode, setDarkMode] = useState<boolean | null>(null);
-  useEffect(() => {
-    const updateColors = () => {
-      const isDarkMode = document.documentElement.classList.contains('dark');
-      if (isDarkMode) {
-        defaults.borderColor = '#545864';
-        defaults.color = '#bdbfc7';
-      } else {
-        defaults.borderColor = '#bdbfc7';
-        defaults.color = '#545864';
-      }
-      setDarkMode(isDarkMode);
-    };
-    updateColors();
+  const isDarkMode = useDarkMode();
 
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (mutation.attributeName === 'class') {
-          updateColors();
-        }
-      }
-    });
-    observer.observe(document.documentElement, { attributes: true });
-  }, []);
-  const color = darkMode ? '#54527b' : '#dcc9e8';
+  defaults.borderColor = isDarkMode ? '#545864' : '#bdbfc7';
+  defaults.color = isDarkMode ? '#bdbfc7' : '#545864';
+
+  const color = isDarkMode ? '#54527b' : '#dcc9e8';
   const backgroundColor = [color, '#b073d9', color, color];
+
   return (
     <div className="p-4 rounded-lg w-auto min-h-[270px]">
-      {darkMode !== null && (
+      {isDarkMode !== null && (
         <Bar
           redraw
           options={options}

--- a/website/components/useDarkMode.tsx
+++ b/website/components/useDarkMode.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export const useDarkMode = () => {
+  const [isDarkMode, setIsDarkMode] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const detectDarkMode = () => {
+      const isDarkMode = document.documentElement.classList.contains('dark');
+      setIsDarkMode(isDarkMode);
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'class') {
+          detectDarkMode();
+        }
+      }
+    });
+    observer.observe(document.documentElement, { attributes: true });
+
+    detectDarkMode();
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return isDarkMode;
+};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Refactored/cleaned up the Chart component to make styling more consistent.
- Split the dark mode detection logic into a separate hook.
- The `useEffect cleanup` was missing in the original code. handled it in the hook itself.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
