### PR TITLE
fix(react): remove ts-expect-error

### DIFF
--- a/packages/react/block.ts
+++ b/packages/react/block.ts
@@ -1,5 +1,3 @@
-// @ts-expect-error - override react.d.ts
-// prettier-ignore
 import { createElement, Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   block as createBlock,
@@ -8,8 +6,6 @@ import {
   remove$,
 } from '../million/block';
 import { unwrap } from './utils';
-// @ts-expect-error - override react.d.ts
-// prettier-ignore
 import type { FunctionComponentElement, ReactNode, FunctionComponent } from 'react';
 import type { Props } from '../million';
 

--- a/packages/react/for.ts
+++ b/packages/react/for.ts
@@ -1,10 +1,6 @@
-// @ts-expect-error - override react.d.ts
-// prettier-ignore
 import { createElement, memo, useEffect, useRef } from 'react';
 import { arrayMount$, arrayPatch$, arrayRemove$ } from '../million/array';
 import { mapArray } from '../million';
-// @ts-expect-error - override react.d.ts
-// prettier-ignore
 import type { FunctionComponent, ReactNode } from 'react';
 
 const createChildren = (each: any[], getComponent: any) => {

--- a/packages/react/utils.ts
+++ b/packages/react/utils.ts
@@ -1,5 +1,3 @@
-// @ts-expect-error - override react.d.ts
-// prettier-ignore
 import type { ReactNode } from 'react';
 import type { VNode } from '../million';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "moduleResolution": "node",
     "module": "esnext",
     "target": "esnext",
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "paths": {
+      // Make sure the root react.d.ts isn't picked up by TS locally
+      "react": ["node_modules/react"]
+    }
   },
   "include": ["./**/*.ts", "./**/*.tsx"],
   "exclude": ["node_modules", "dist", "*.d.ts", "website"]


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Remove `@ts-expect-error` & `prettier-ignore` from `react` imports. Because we have a root `react.d.ts` definition file due to the `million/react` import, TS picks this file instead of `node_modules/react`

I found this trick of using `paths` inside the tsconfig, not 100% sure that it works.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
