### PR TITLE
Fix typo in virtual-dom.mdx

### DIFF
--- a/website/pages/blog/virtual-dom.mdx
+++ b/website/pages/blog/virtual-dom.mdx
@@ -82,7 +82,7 @@ The Block virtual DOM takes a different approach to diffing, and can be broken d
 
 1. **Static Analysis**: The virtual DOM is analyzed to extract dynamic parts of the tree into a "Edit Map," or the list of the "edits" (mappings) of the dynamic parts of the virtual DOM to the state.
 
-2. **Dirty Checking**: The state (**not** the virtual DOM tree) is diffed the to determine what has changed. If the state has changed, the DOM is updated directly via the Edit Map.
+2. **Dirty Checking**: The state (**not** the virtual DOM tree) is diffed to determine what has changed. If the state has changed, the DOM is updated directly via the Edit Map.
 
 Since Million.js takes a similar approach to Blockdom, we'll be using Million.js syntax for the rest of this article.
 


### PR DESCRIPTION
A small update in the docs:
Line 85: 2. Dirty Checking...
"is diffed the to determine what has changed" should be "is diffed to determine what has changed"
