### PR TITLE
Ignore null, undefined, false in block rendering

### DIFF
--- a/packages/million/block.ts
+++ b/packages/million/block.ts
@@ -146,6 +146,11 @@ export class Block extends AbstractBlock {
             insertBefore$.call(el, parent, childNodes[edit.i!]);
             continue;
           }
+
+          if (value === null || value === undefined || value === false) {
+            continue
+          }
+
           // insertText() on mount, setText() on patch
           insertText(el, String(value), edit.i!);
         } else if (edit.t & EventFlag) {
@@ -227,6 +232,11 @@ export class Block extends AbstractBlock {
           if (typeof oldValue === 'function') {
             continue;
           }
+
+          if (newValue === null || newValue === undefined || newValue === false) {
+            continue
+          }
+
           setText(el, String(newValue), edit.i!);
         } else if (edit.t & AttributeFlag) {
           setAttribute(el, edit.n!, newValue);

--- a/packages/million/block.ts
+++ b/packages/million/block.ts
@@ -148,7 +148,7 @@ export class Block extends AbstractBlock {
           }
 
           if (value === null || value === undefined || value === false) {
-            continue
+            continue;
           }
 
           // insertText() on mount, setText() on patch
@@ -233,8 +233,12 @@ export class Block extends AbstractBlock {
             continue;
           }
 
-          if (newValue === null || newValue === undefined || newValue === false) {
-            continue
+          if (
+            newValue === null ||
+            newValue === undefined ||
+            newValue === false
+          ) {
+            continue;
           }
 
           setText(el, String(newValue), edit.i!);

--- a/test/block.test.tsx
+++ b/test/block.test.tsx
@@ -57,4 +57,20 @@ describe.concurrent('block', () => {
     main.x();
     expect(main.l).toBeNull();
   });
+  it('should ignore null, undefined, false', () => {
+    const block = createBlock(fn);
+    const main = block({ foo: null, bar: 'bar' });
+    main.m();
+    expect(main.l?.outerHTML).toEqual(
+      '<div><h1>Hello</h1> World<p title="baz" class="bar"></p></div>',
+    );
+    main.p(block({ foo: undefined, bar: 'bar' }));
+    expect(main.l?.outerHTML).toEqual(
+      '<div><h1>Hello</h1> World<p title="baz" class="bar"></p></div>',
+    );
+    main.p(block({ foo: false, bar: 'bar' }));
+    expect(main.l?.outerHTML).toEqual(
+      '<div><h1>Hello</h1> World<p title="baz" class="bar"></p></div>',
+    );
+  });
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

```null```, ```undefined```, ```false``` are ignored in ```renderToTemplate```, but not in block mount and patch
https://github.com/aidenybai/million/blob/main/packages/million/template.ts#L28
https://github.com/aidenybai/million/blob/main/packages/million/template.ts#L138