### PR TITLE
perf: childAt helper and cache

### DIFF
--- a/packages/compiler/optimize.ts
+++ b/packages/compiler/optimize.ts
@@ -190,13 +190,15 @@ export const optimize = (path: NodePath<t.CallExpression>) => {
         ),
         t.variableDeclarator(
           getElementsVariable,
-          t.arrowFunctionExpression(
-            [t.identifier('root')],
-            t.blockStatement([
-              t.variableDeclaration('const', declarators),
-              t.returnStatement(t.arrayExpression(accessedIds)),
-            ]),
-          ),
+          declarators.length
+            ? t.arrowFunctionExpression(
+                [t.identifier('root')],
+                t.blockStatement([
+                  t.variableDeclaration('const', declarators),
+                  t.returnStatement(t.arrayExpression(accessedIds)),
+                ]),
+              )
+            : t.nullLiteral(),
         ),
       ]);
       const BlockClass = addNamed(path, 'Block', importSource.source.value, {

--- a/packages/compiler/react.ts
+++ b/packages/compiler/react.ts
@@ -41,7 +41,7 @@ export const transformReact =
         );
       }
       const componentBinding = path.scope.getBinding(componentId.name);
-      const component = structuredClone(componentBinding?.path.node);
+      const component = t.cloneNode(componentBinding?.path.node);
 
       if (t.isFunctionDeclaration(component)) {
         handleComponent(

--- a/packages/compiler/react.ts
+++ b/packages/compiler/react.ts
@@ -41,7 +41,7 @@ export const transformReact =
         );
       }
       const componentBinding = path.scope.getBinding(componentId.name);
-      const component = { ...componentBinding?.path.node };
+      const component = structuredClone(componentBinding?.path.node);
 
       if (t.isFunctionDeclaration(component)) {
         handleComponent(
@@ -131,7 +131,11 @@ const handleComponent = (
     const blockFunction = t.functionDeclaration(
       blockVariable,
       // Destructures props
-      [t.objectPattern(dynamics.map(({ id }) => t.objectProperty(id, id)))],
+      [
+        t.objectPattern(
+          dynamics.data.map(({ id }) => t.objectProperty(id, id)),
+        ),
+      ],
       t.blockStatement([view]),
     );
 
@@ -140,13 +144,15 @@ const handleComponent = (
       t.callExpression(forgettiCompatibleComponentName, [
         t.objectExpression(
           // Creates an object that passes expression values down
-          dynamics.map(({ id, value }) => t.objectProperty(id, value || id)),
+          dynamics.data.map(({ id, value }) =>
+            t.objectProperty(id, value || id),
+          ),
         ),
       ]),
     );
 
-    for (let i = 0; i < dynamics.length; ++i) {
-      dynamics[i]?.callback?.();
+    for (let i = 0; i < dynamics.deferred.length; ++i) {
+      dynamics.deferred[i]?.();
     }
 
     // Swaps the names of the functions so that the component that wraps the
@@ -178,10 +184,13 @@ const getDynamicsFromJSX = (
   sourceName: string,
   returnJsxPath: any,
   dynamics: {
-    id: t.Identifier;
-    value: t.Expression | null;
-    callback: (() => void) | null;
-  }[] = [],
+    cache: Set<string>;
+    data: {
+      id: t.Identifier;
+      value: t.Expression | null;
+    }[];
+    deferred: (() => void)[];
+  } = { data: [], cache: new Set(), deferred: [] },
 ) => {
   const createDynamic = (
     identifier: t.Identifier | null,
@@ -189,7 +198,11 @@ const getDynamicsFromJSX = (
     callback: (() => void) | null,
   ) => {
     const id = identifier || path.scope.generateUidIdentifier('$');
-    dynamics.push({ value: expression, id, callback });
+    if (!dynamics.cache.has(id.name)) {
+      dynamics.data.push({ value: expression, id });
+      dynamics.cache.add(id.name);
+    }
+    dynamics.deferred.push(callback!);
     return id;
   };
 

--- a/packages/million/constants.ts
+++ b/packages/million/constants.ts
@@ -18,6 +18,7 @@ export const StyleAttributeFlag = 8;
 export const SvgAttributeFlag = 16;
 export const BlockFlag = 32;
 
+export const TEXT_NODE_CACHE = '__t'
 export const EVENTS_REGISTRY = '__m';
 export const IS_NON_DIMENSIONAL =
   /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;

--- a/packages/million/dom.ts
+++ b/packages/million/dom.ts
@@ -41,7 +41,6 @@ export const setTextContent$ = getOwnPropertyDescriptor$(node$, 'textContent')!
   .set!;
 export const innerHTML$ = getOwnPropertyDescriptor$(element$, 'innerHTML')!
   .set!;
-export const childNodes$ = getOwnPropertyDescriptor$(node$, 'childNodes')!.get!;
 export const firstChild$ = getOwnPropertyDescriptor$(node$, 'firstChild')!.get!;
 export const nextSibling$ = getOwnPropertyDescriptor$(node$, 'nextSibling')!
   .get!;
@@ -96,19 +95,31 @@ export const createEventListener = (
   return patch;
 };
 
+// https://www.measurethat.net/Benchmarks/Show/15652/0/childnodes-vs-children-vs-firstchildnextsibling-vs-firs
+export const childAt = (el: HTMLElement, index: number) => {
+  let child = firstChild$.call(el);
+  if (index) {
+    for (let j = 0; j < index; ++j) {
+      if (!child) break;
+      child = nextSibling$.call(child);
+    }
+  }
+  return child;
+};
+
 export const insertText = (
   el: HTMLElement,
   value: any,
   index: number,
 ): Text => {
   const node = document$.createTextNode(value);
-  const childNodes = childNodes$.call(el);
-  insertBefore$.call(el, node, childNodes[index]);
+  const child = childAt(el, index);
+  insertBefore$.call(el, node, child);
   return node;
 };
 
-export const setText = (el: HTMLElement, value: string, index: number) => {
-  characterDataSet$.call(childNodes$.call(el)[index], value);
+export const setText = (el: Text, value: string) => {
+  characterDataSet$.call(el, value);
 };
 
 export const setStyleAttribute = (

--- a/packages/react/for.ts
+++ b/packages/react/for.ts
@@ -1,81 +1,39 @@
 import { createElement, memo, useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
-import { arrayMount$, arrayPatch$, arrayRemove$ } from '../million/array';
+import { arrayMount$, arrayPatch$ } from '../million/array';
 import { mapArray, block as createBlock } from '../million';
 import { MapSet$, MapHas$, MapGet$ } from '../million/constants';
 import { REGISTRY } from './block';
 import type { Props } from '../million';
-import type { FC, ReactNode } from 'react';
+import type { FC, ReactNode, MutableRefObject } from 'react';
 
-const createChildren = (
-  each: any[],
-  getComponent: any,
-  prevEach: any[],
-  prevChildren: any[],
-) => {
-  const children = Array(each.length);
-  for (let i = 0, l = each.length; i < l; ++i) {
-    if (each[i] === prevEach[i]) {
-      children[i] = prevChildren[i];
-      continue;
-    }
-    const vnode = getComponent(each[i], i);
-
-    if (MapHas$.call(REGISTRY, vnode.type)) {
-      const registeredComponent = MapGet$.call(REGISTRY, vnode.type)!;
-      children[i] = registeredComponent(vnode.props);
-    } else {
-      const block = createBlock((props?: Props) => {
-        return {
-          type: 'million-block',
-          props: { children: [props?.__l] },
-        } as any;
-      });
-      const registeredComponent = (props: Props) => {
-        return block({
-          props,
-          __l: (el: HTMLElement) => {
-            createRoot(el).render(createElement(vnode.type, props));
-          },
-        });
-      };
-
-      MapSet$.call(REGISTRY, vnode.type, registeredComponent);
-      children[i] = registeredComponent(vnode.props);
-    }
-  }
-  return children;
-};
-
-const MillionArray: FC<{
+interface MillionArrayProps {
   each: any[];
   children: (value: any, i: number) => ReactNode;
-}> = ({ each, children }) => {
+}
+
+interface ArrayCache {
+  each: any[] | null;
+  children: any[] | null;
+  block?: ReturnType<typeof createBlock>;
+}
+
+const MillionArray: FC<MillionArrayProps> = ({ each, children }) => {
   const ref = useRef<HTMLElement>(null);
   const fragmentRef = useRef<ReturnType<typeof mapArray> | null>(null);
-  const prevEach = useRef<any[]>(Array(each.length));
-  const prevChildren = useRef<any[]>(Array(each.length));
-  if (fragmentRef.current) {
-    const newChildren = createChildren(
-      each,
-      children,
-      prevEach.current,
-      prevChildren.current,
-    );
+  const cache = useRef<ArrayCache>({
+    each: null,
+    children: null,
+  });
+  if (fragmentRef.current && each !== cache.current.each) {
+    const newChildren = createChildren(each, children, cache);
     arrayPatch$.call(fragmentRef.current, mapArray(newChildren));
   }
   useEffect(() => {
-    const newChildren = createChildren(
-      each,
-      children,
-      prevEach.current,
-      prevChildren.current,
-    );
+    if (fragmentRef.current) return;
+    const newChildren = createChildren(each, children, cache);
     fragmentRef.current = mapArray(newChildren);
     arrayMount$.call(fragmentRef.current, ref.current!);
-    return () => {
-      arrayRemove$.call(fragmentRef.current);
-    };
   }, []);
 
   return createElement('million-fragment', { ref });
@@ -84,3 +42,47 @@ const MillionArray: FC<{
 export const For = memo(MillionArray, (oldProps, newProps) =>
   Object.is(newProps.each, oldProps.each),
 );
+
+const createChildren = (
+  each: any[],
+  getComponent: any,
+  cache: MutableRefObject<ArrayCache>,
+) => {
+  const children = Array(each.length);
+  for (let i = 0, l = each.length; i < l; ++i) {
+    if (cache.current.each && cache.current.each[i] === each[i]) {
+      children[i] = cache.current.children?.[i];
+      continue;
+    }
+    const vnode = getComponent(each[i], i);
+
+    if (MapHas$.call(REGISTRY, vnode.type)) {
+      if (!cache.current.block) {
+        cache.current.block = MapGet$.call(REGISTRY, vnode.type)!;
+      }
+      children[i] = cache.current.block!(vnode.props);
+    } else {
+      const block = createBlock((props?: Props) => {
+        return {
+          type: 'million-block',
+          props: { children: [props?.__l] },
+        } as any;
+      });
+      const currentBlock = (props: Props) => {
+        return block({
+          props,
+          __l: (el: HTMLElement) => {
+            createRoot(el).render(createElement(vnode.type, props));
+          },
+        });
+      };
+
+      MapSet$.call(REGISTRY, vnode.type, currentBlock);
+      cache.current.block = currentBlock as ReturnType<typeof createBlock>;
+      children[i] = currentBlock(vnode.props);
+    }
+  }
+  cache.current.each = each;
+  cache.current.children = children;
+  return children;
+};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR introduces two performance improvements:

**1. Improve node traversal within edits.**

Currently, we use efficient node traversal (via `firstChild` and `nextSibling`) for paths, but we still use `childNodes` in some places. This PR replaces `childNodes` with a `childAt` helper function, which internally uses the efficient node traversal method.

**2. Cache text nodes once traversed**

Within child edits, we traverse to a certain index and change the text value, for both mount and patch. With this change, traversal is only done at mount to determine the location of the text node, cached on the current path element, then accessed later during patch. This prevents unnecessary traversal and allows us to directly do pinpoint changes.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
