### PR TITLE
Update quickstart.mdx to include Gatsby in <Tabs> items array

### DIFF
--- a/website/pages/docs/quickstart.mdx
+++ b/website/pages/docs/quickstart.mdx
@@ -40,7 +40,7 @@ Otherwise, inside your project directory, run the following command:
 
 Then, add the compiler to your bundler of choice:
 
-<Tabs items={['Next.js', 'Astro', 'Vite', 'Webpack', 'Rollup', 'Rspack', 'Esbuild']} storageKey="selected-bundler-compiler">
+<Tabs items={['Next.js', 'Astro', 'Gatsby', 'Vite', 'Webpack', 'Rollup', 'Rspack', 'Esbuild']} storageKey="selected-bundler-compiler">
   <Tab>
   <Callout>
     Next.js support is currently in beta. Please report any issues you encounter.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The quickstart page has incorrect configs after the Astro config. This is because Gatsby was added as a `<Tab>` to the .mdx file but not in the items array in `<Tabs>`

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
