### PR TITLE
test: add concurrent test

### DIFF
--- a/test/block.test.tsx
+++ b/test/block.test.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { block as createBlock } from '../packages/million';
 import type { Props, VElement } from '../packages/million';
 
@@ -14,12 +14,12 @@ const fn = (props?: Props): VElement => (
 );
 
 describe.concurrent('block', () => {
-  it('should create reusable block', () => {
+  it('should create reusable block', ({ expect }) => {
     const block = createBlock(fn);
     expect(block).toBeDefined();
     expect(block({ foo: 'foo', bar: 'bar' })).toBeDefined();
   });
-  it('should mount block', () => {
+  it('should mount block', ({ expect }) => {
     const block = createBlock(fn);
     const main = block({ foo: 'foo', bar: 'bar' });
     main.m();
@@ -27,7 +27,7 @@ describe.concurrent('block', () => {
       '<div><h1>Hello</h1> World<p title="baz" class="bar">foo</p></div>',
     );
   });
-  it('should patch block', () => {
+  it('should patch block', ({ expect }) => {
     const block = createBlock(fn);
     const main = block({ foo: 'foo', bar: 'bar' });
     main.m();
@@ -40,7 +40,7 @@ describe.concurrent('block', () => {
       '<div><h1>Hello</h1> World<p title="baz" class="bar">bar</p></div>',
     );
   });
-  it('should patch nested blocks', () => {
+  it('should patch nested blocks', ({ expect }) => {
     const block = createBlock(fn);
     const subBlock = createBlock(fn);
     const main = block({ foo: subBlock({ foo: '1', bar: '2' }), bar: 'bar' });
@@ -50,14 +50,14 @@ describe.concurrent('block', () => {
       '<div><h1>Hello</h1> World<p title="baz" class="bar"><div><h1>Hello</h1> World<p title="baz" class="1">2</p></div></p></div>',
     );
   });
-  it('should remove block', () => {
+  it('should remove block', ({ expect }) => {
     const block = createBlock(fn);
     const main = block({ foo: 'foo', bar: 'bar' });
     main.m();
     main.x();
     expect(main.l).toBeNull();
   });
-  it('should ignore null, undefined, false', () => {
+  it('should ignore null, undefined, false', ({ expect }) => {
     const block = createBlock(fn);
     const main = block({ foo: null, bar: 'bar' });
     main.m();

--- a/test/map-array.test.tsx
+++ b/test/map-array.test.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { block as createBlock, mapArray } from '../packages/million';
 import type { Props, VElement } from '../packages/million';
 
@@ -14,14 +14,14 @@ const fn = (props?: Props): VElement => (
 );
 
 describe.concurrent('block', () => {
-  it('should mount block', () => {
+  it('should mount block', ({ expect }) => {
     const parent = document.createElement('div');
     const block = createBlock(fn);
     const arr = mapArray([block({ foo: 'foo', bar: 'bar' })]);
     arr.m(parent);
     expect(arr.t()).toEqual(parent);
   });
-  it('should patch block', () => {
+  it('should patch block', ({ expect }) => {
     const parent = document.createElement('div');
     const block = createBlock(fn);
     const arr = mapArray([block({ foo: 'foo', bar: 'bar' })]);
@@ -42,7 +42,7 @@ describe.concurrent('block', () => {
     arr.p(mapArray([]));
     expect(arr.t()?.outerHTML).toEqual('<div></div>');
   });
-  it('should remove fragment', () => {
+  it('should remove fragment', ({ expect }) => {
     const parent = document.createElement('div');
     const block = createBlock(fn);
     const arr = mapArray([block({ foo: 'foo', bar: 'bar' })]);

--- a/test/preact-compiler.test.tsx
+++ b/test/preact-compiler.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { parseSync } from '@babel/core';
+import { describe, it } from 'vitest';
+import { parseAsync } from '@babel/core';
 import million from '../packages/compiler';
 
 const BABEL_CONFIG = {
@@ -7,8 +7,8 @@ const BABEL_CONFIG = {
 };
 
 describe('preact-compiler', () => {
-  it('should compile hooks', () => {
-    const ast = parseSync(
+  it('should compile hooks', async ({ expect }) => {
+    const ast = await parseAsync(
       `
       import { h, render } from 'preact';
       import { useState } from 'preact/hooks';
@@ -38,8 +38,8 @@ describe('preact-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile objects', () => {
-    const ast = parseSync(
+  it('should compile objects', async ({ expect }) => {
+    const ast = await parseAsync(
       `
       import { h, render } from 'preact';
       import { block } from 'million/preact';
@@ -64,8 +64,8 @@ describe('preact-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile derived values', () => {
-    const ast = parseSync(
+  it('should compile derived values', async ({ expect }) => {
+    const ast = await parseAsync(
       `
       import { h, render } from 'preact';
       import { block } from 'million/preact';
@@ -90,8 +90,8 @@ describe('preact-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile event listeners', () => {
-    const ast = parseSync(
+  it('should compile event listeners', async ({ expect }) => {
+    const ast = await parseAsync(
       `
       import { h, render } from 'preact';
       import { block } from 'million/preact';
@@ -117,8 +117,8 @@ describe('preact-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile identifiers', () => {
-    const ast = parseSync(
+  it('should compile identifiers', async ({ expect }) => {
+    const ast = await parseAsync(
       `
       import { h, render } from 'preact';
       import { block } from 'million/preact';

--- a/test/react-compiler.test.tsx
+++ b/test/react-compiler.test.tsx
@@ -1,14 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { parseSync } from '@babel/core';
+import { describe, it } from 'vitest';
+import { parseAsync } from '@babel/core';
 import million from '../packages/compiler';
 
 const BABEL_CONFIG = {
   plugins: ['@babel/plugin-syntax-jsx', million.babel],
 };
 
-describe('react-compiler', () => {
-  it('should compile hooks', () => {
-    const ast = parseSync(
+describe.concurrent('react-compiler', () => {
+  it('should compile hooks', async ({ expect }) => {
+    const ast = await parseAsync(
       `
         import React, { useState } from 'react';
         import { createRoot } from 'react-dom/client';
@@ -35,8 +35,8 @@ describe('react-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile objects', () => {
-    const ast = parseSync(
+  it('should compile objects', async ({ expect }) => {
+    const ast = await parseAsync(
       `
         import React, { useState } from 'react';
         import { createRoot } from 'react-dom/client';
@@ -61,8 +61,8 @@ describe('react-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile derived values', () => {
-    const ast = parseSync(
+  it('should compile derived values', async ({ expect }) => {
+    const ast = await parseAsync(
       `
         import React, { useState } from 'react';
         import { createRoot } from 'react-dom/client';
@@ -87,8 +87,8 @@ describe('react-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile event listeners', () => {
-    const ast = parseSync(
+  it('should compile event listeners', async ({ expect }) => {
+    const ast = await parseAsync(
       `
         import React, { useState } from 'react';
         import { createRoot } from 'react-dom/client';
@@ -113,8 +113,8 @@ describe('react-compiler', () => {
     expect(ast).toMatchSnapshot();
   });
 
-  it('should compile identifiers', () => {
-    const ast = parseSync(
+  it('should compile identifiers', async ({ expect }) => {
+    const ast = await parseAsync(
       `
         import React, { useState } from 'react';
         import { createRoot } from 'react-dom/client';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

---

The PR does the following things:

- Remove `expect` import from the `vitest`.
  - Always prefer `expect` from `it` context as it is required for concurrent testing + snapshot + assertions. This can ease future concurrent testing migration.
- Enable `concurrent` for react/preact compiler testing.
- Use `babel.parseAsync` instead of `babel.parseSync` in tests.