### PR TITLE
feat: Add support for aliases in the 'block' function import from the 'million/react' module

### DIFF
--- a/packages/compiler/react/bindings.ts
+++ b/packages/compiler/react/bindings.ts
@@ -3,7 +3,6 @@ import type { NodePath } from '@babel/core';
 
 export function collectImportedBindings(
   path: NodePath<t.Program>,
-  moduleName: string,
 ): Record<string, string> {
   const importedBindings: Record<string, string> = {};
 
@@ -14,13 +13,12 @@ export function collectImportedBindings(
   for (const importDeclaration of importDeclarations) {
     if (
       t.isImportDeclaration(importDeclaration.node) &&
-      importDeclaration.node.source.value === moduleName
+      importDeclaration.node.source.value.includes('million')
     ) {
       for (const specifier of importDeclaration.node.specifiers) {
         if (
           t.isImportSpecifier(specifier) &&
-          t.isIdentifier(specifier.imported) &&
-          specifier.imported.name === 'million/react'
+          t.isIdentifier(specifier.imported)
         ) {
           importedBindings[specifier.imported.name] = specifier.local.name;
         }

--- a/packages/compiler/react/bindings.ts
+++ b/packages/compiler/react/bindings.ts
@@ -1,0 +1,32 @@
+import * as t from '@babel/types';
+import type { NodePath } from '@babel/core';
+
+export function collectImportedBindings(
+  path: NodePath<t.Program>,
+  moduleName: string,
+): Record<string, string> {
+  const importedBindings: Record<string, string> = {};
+
+  const importDeclarations = path
+    .get('body')
+    .filter((node) => t.isImportDeclaration(node.node));
+
+  for (const importDeclaration of importDeclarations) {
+    if (
+      t.isImportDeclaration(importDeclaration.node) &&
+      importDeclaration.node.source.value === moduleName
+    ) {
+      for (const specifier of importDeclaration.node.specifiers) {
+        if (
+          t.isImportSpecifier(specifier) &&
+          t.isIdentifier(specifier.imported) &&
+          specifier.imported.name === 'million/react'
+        ) {
+          importedBindings[specifier.imported.name] = specifier.local.name;
+        }
+      }
+    }
+  }
+
+  return importedBindings;
+}

--- a/packages/compiler/react/visitor.ts
+++ b/packages/compiler/react/visitor.ts
@@ -2,6 +2,7 @@ import * as t from '@babel/types';
 import { addNamed } from '@babel/helper-module-imports';
 import { createDeopt, resolveCorrectImportSource, resolvePath } from './utils';
 import { transformComponent } from './transform';
+import { collectImportedBindings } from './bindings';
 import type { NodePath } from '@babel/core';
 import type { Options } from '../plugin';
 
@@ -15,8 +16,16 @@ export const visitor = (options: Options = {}, isReact = true) => {
     const globalPath = callSitePath.parentPath.parentPath!;
 
     // We only want to optimize block calls.
-    // TODO: check if the block is aliased (e.g. import { block as createBlock } ...)
-    if (!t.isIdentifier(callSite.callee, { name: 'block' })) return;
+    // check if the block is aliased (e.g. import { block as createBlock } ...)
+    const programPath = callSitePath.findParent((path) =>
+      path.isProgram(),
+    ) as NodePath<t.Program>;
+    const importedBlocks = collectImportedBindings(programPath, 'block');
+    if (
+      !t.isIdentifier(callSite.callee) ||
+      !importedBlocks[callSite.callee.name]
+    )
+      return;
 
     // Allow the user to opt into experimental optimization by adding a /* @optimize */
     // to the block call.
@@ -58,7 +67,14 @@ export const visitor = (options: Options = {}, isReact = true) => {
      */
     if (
       !t.isImportDeclaration(importDeclaration) ||
-      !importDeclaration.source.value.includes('million')
+      !importDeclaration.source.value.includes('million') ||
+      !importDeclaration.specifiers.some(
+        (specifier) =>
+          t.isImportSpecifier(specifier) &&
+          t.isIdentifier(specifier.imported) &&
+          specifier.imported.name === 'block' &&
+          importedBlocks['block'] === specifier.local.name,
+      )
     ) {
       const millionImportDeclarationPath = blockCallBinding.path.parentPath!;
       throw createDeopt(

--- a/packages/compiler/react/visitor.ts
+++ b/packages/compiler/react/visitor.ts
@@ -20,7 +20,7 @@ export const visitor = (options: Options = {}, isReact = true) => {
     const programPath = callSitePath.findParent((path) =>
       path.isProgram(),
     ) as NodePath<t.Program>;
-    const importedBlocks = collectImportedBindings(programPath, 'block');
+    const importedBlocks = collectImportedBindings(programPath);
     if (
       !t.isIdentifier(callSite.callee) ||
       !importedBlocks[callSite.callee.name]

--- a/packages/compiler/react/visitor.ts
+++ b/packages/compiler/react/visitor.ts
@@ -73,7 +73,7 @@ export const visitor = (options: Options = {}, isReact = true) => {
           t.isImportSpecifier(specifier) &&
           t.isIdentifier(specifier.imported) &&
           specifier.imported.name === 'block' &&
-          importedBlocks['block'] === specifier.local.name,
+          importedBlocks.block === specifier.local.name,
       )
     ) {
       const millionImportDeclarationPath = blockCallBinding.path.parentPath!;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR introduces the ability to support aliases for imported functions from the 'million' module, including the 'block' function. This allows functions to be imported under a different name and still be correctly recognized.

Specifically, the following changes have been implemented:

1. Created a `collectImportedBindings` function that collects all bindings imported from any module containing 'million' in its name.
2. In `visitor.ts`, instead of checking if a function is being called by the name 'block', it checks if an alias of 'block' is being used.
3. The ImportDeclaration now checks if the 'block' function from the 'million' module is being imported and if the local name matches the alias name for 'block'.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
