### PR TITLE
fix: wrong link to `stringToDOM()`

### DIFF
--- a/website/pages/docs/render-to-template.mdx
+++ b/website/pages/docs/render-to-template.mdx
@@ -17,7 +17,7 @@ import { Callout } from 'nextra-theme-docs';
 **Syntax:** `stringToDOM(vnode, edits){:jsx}`\
 **Example:** `stringToDOM(<div>Hello World</div>, []){:jsx}`
 
-The `renderToTemplate()` function is used to render a virtual DOM node to a string. This is used to create the template for the block and works tangentially with [`stringToDOM(){:jsx}`](/docs/api/string-to-dom).
+The `renderToTemplate()` function is used to render a virtual DOM node to a string. This is used to create the template for the block and works tangentially with [`stringToDOM(){:jsx}`](/docs/string-to-dom).
 
 ```jsx
 import { renderToTemplate } from 'million';


### PR DESCRIPTION
**Status**

- [X] Code changes have been tested against prettier, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
