### PR TITLE
feat: add craco.js config to quickstart

### DIFF
--- a/website/pages/docs/install.mdx
+++ b/website/pages/docs/install.mdx
@@ -44,7 +44,7 @@ Then, add the compiler to your build tool of choice:
 
 <details open>
   <summary>React Instructions</summary>
-  <Tabs items={['Next.js', 'Astro', 'Gatsby', 'Vite', 'Webpack', 'Rollup']} storageKey="selected-bundler-compiler">
+  <Tabs items={['Next.js', 'Astro', 'Gatsby', 'Vite', 'Webpack', 'Rollup', 'Craco.js']} storageKey="selected-bundler-compiler">
     <Tab>
     Million.js is supported within the `/app` ("use client" components only) and `/pages`
 
@@ -108,6 +108,23 @@ Then, add the compiler to your build tool of choice:
     export default {
       plugins: [million.rollup()],
     };
+    ```
+    </Tab>
+      <Tab>
+    ```js filename="craco.config.js"
+    const million = require("million/compiler");
+
+    module.exports = {
+      // ...
+      webpack: {
+       // ...
+       plugins: {
+        add: [million.webpack()],
+       // ...
+       },
+      //  ...
+     };
+   }
     ```
     </Tab>
   </Tabs>


### PR DESCRIPTION
I added the configuration for million when using [CRACO](https://craco.js.org/docs/configuration/webpack/); an alternative to CRA. 

This resolves issue #388 

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
