### PR TITLE
fix-duplicate-words-in-installation-guide-in-quickstart.mdx

### DIFF
--- a/website/pages/docs/quickstart.mdx
+++ b/website/pages/docs/quickstart.mdx
@@ -355,7 +355,7 @@ export default App;
 ## Hitting the limit
 
 <Callout type="warning">
-  This section is a bit more advanced. If you want a list of limitations, check out the [Rules of Blocks](/docs/rules). Or, if you just want to start integrating Million.js, check out the the [installation guide](/docs/install).
+  This section is a bit more advanced. If you want a list of limitations, check out the [Rules of Blocks](/docs/rules). Or, if you just want to start integrating Million.js, check out the [installation guide](/docs/install).
 </Callout>
 
 Blocks are great for rendering large lists, data grids, and many other use cases. Under the hood, they render with the Million.js virtual DOM instead of React.
@@ -385,7 +385,7 @@ Looking for the full guidelines? Check out [Rules of Blocks](/docs/rules).
 
 By now, you know the basics of how to integrate Million.js into your application!
 
-Check out the the [installation guide](/docs/install) to put them into practice and start using blocks.
+Check out the [installation guide](/docs/install) to put them into practice and start using blocks.
 
 ---
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request aims to improve the installation documentation in the quickstart.mdx file. It addresses two issues identified in the existing documentation:

Problem 1: "Check out the the installation...."
Solution: Removed the duplicate "the" from the sentence to make it more concise and grammatically correct. Updated the sentence to: "Check out the installation..."

Problem 2: "check out the the installation guide...."
Solution: Removed the duplicate "the" from the sentence to enhance readability and consistency. Updated the sentence to: "Check out the installation guide..."

These changes aim to provide clearer instructions and improve the overall quality of the documentation for users who are getting started with the "million" project.

I have tested the changes locally and verified that they do not introduce any unintended side effects. The documentation now reflects the intended instructions accurately.

I'm excited to contribute to this project and look forward to your feedback and suggestions for further improvements.

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
