### PR TITLE
docs: fix the link to map-array page from quickstart page

### DIFF
--- a/website/pages/docs/quickstart.mdx
+++ b/website/pages/docs/quickstart.mdx
@@ -286,7 +286,7 @@ Syntax: `<For each={array}>{(item, index) => Block}</For>{:jsx}`\
 Example: `<For each={[1, 2, 3]}>{(item, index) => myBlock({ item, index })}</For>{:jsx}`
 </Callout>
 
-It's the best way to loop over an array (uses [`mapArray(){:jsx}`](/map-array) under the hood). As the array changes, `<For />{:jsx}` updates or moves items in the DOM rather than recreating them. Let's look at an example:
+It's the best way to loop over an array (uses [`mapArray(){:jsx}`](/docs/map-array) under the hood). As the array changes, `<For />{:jsx}` updates or moves items in the DOM rather than recreating them. Let's look at an example:
 
 With this in mind, we can rewrite our table to use `<For />{:jsx}`:
 


### PR DESCRIPTION
Updates the link to [map-array](https://million.dev/docs/map-array) page from [quickstart](https://million.dev/docs/quickstart) page to point to correct location `/docs/map-array`.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
