### PR TITLE
Handle direct JSX return in arrow functions

### DIFF
--- a/packages/compiler/react/visitor.ts
+++ b/packages/compiler/react/visitor.ts
@@ -186,6 +186,28 @@ export const visitor = (options: Options = {}, isReact = true) => {
       t.isVariableDeclarator(Component) &&
       t.isArrowFunctionExpression(Component.init)
     ) {
+      if (
+        !t.isBlockStatement(Component.init.body) &&
+        t.isJSXElement(Component.init.body)
+      ) {
+        /**
+         * If the function body directly returns a JSX element (i.e., not wrapped in a BlockStatement),
+         * we transform the JSX return into a BlockStatement before passing it to `transformComponent()`.
+         *
+         * ```jsx
+         * const Component = () => <div></div>
+         *
+         * // becomes
+         * const Component = () => {
+         *   return <div></div>
+         * }
+         * ```
+         */
+        Component.init.body = t.blockStatement([
+          t.returnStatement(Component.init.body),
+        ]);
+      }
+
       /*
        * Variable Declaration w/ Arrow Function:
        *


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR addresses a scenario where the component body returns a JSX expression directly, without wrapping it in a BlockStatement.

Previously, the following code would throw an error:
```jsx
const Component = () => <div></div>
```

because the `transformComponent` function in `visitor.ts` expects a `t.BlockStatement` as argument.

With these changes, we now transform the returned JSX expression into a `BlockStatement` before passing it to `transformComponent`, enabling us to correctly handle direct JSX return in arrow functions.


**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
