### PR TITLE
Docs: typo

### DIFF
--- a/website/pages/docs/rules.mdx
+++ b/website/pages/docs/rules.mdx
@@ -74,7 +74,7 @@ const BadBlock = block(<Component />) // ❌ Wrong
 const GoodBlock = block(App)  // ✅ Correct
 ```
 
-### Using `map()` instead of `<For />`
+### Using `<For />` instead of `map()`
 
 <Callout type="warning">
   <code>


### PR DESCRIPTION
Original: Using map() instead of <For />
Changed: Using `<For />` instead of `map()`

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
