### PR TITLE
refactor(compiler): destroy original component to reduce compilation time

### DIFF
--- a/packages/compiler/experimental/utils.ts
+++ b/packages/compiler/experimental/utils.ts
@@ -33,10 +33,9 @@ export const createEdit = ({
 
 export const chainOrLogic = (
   ...binaryExpressions: t.BinaryExpression[]
-): t.LogicalExpression | t.BinaryExpression => {
-  if (binaryExpressions.length === 1) {
-    return binaryExpressions[0]!;
-  }
+): t.LogicalExpression | t.BinaryExpression | t.BooleanLiteral => {
+  if (binaryExpressions.length === 0) return t.booleanLiteral(true);
+  if (binaryExpressions.length === 1) return binaryExpressions[0]!;
 
   const [first, ...rest] = binaryExpressions;
 

--- a/packages/compiler/react/utils.ts
+++ b/packages/compiler/react/utils.ts
@@ -18,7 +18,8 @@ export const createError = (message: string, path: NodePath) => {
   return path.buildCodeFrameError(`[Million.js] ${message}`);
 };
 
-export const warn = (message: string, path: NodePath) => {
+export const warn = (message: string, path: NodePath, mute?: boolean) => {
+  if (mute) return;
   const err = createError(message, path);
   // eslint-disable-next-line no-console
   console.warn(

--- a/packages/react/constants.ts
+++ b/packages/react/constants.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import type { FC } from 'react';
+import type { ComponentType, FC } from 'react';
 
 export const RENDER_SCOPE = 'slot';
 export const REACT_ROOT = '__react_root';
@@ -8,3 +8,5 @@ export const Effect: FC<{ effect: () => void }> = ({ effect }) => {
   useEffect(effect, []);
   return null;
 };
+
+export const REGISTRY = new Map<ComponentType, any>();

--- a/website/pages/docs/install.mdx
+++ b/website/pages/docs/install.mdx
@@ -189,6 +189,7 @@ interface Options {
   mode: 'react' | 'preact' | 'vdom' // default: 'react'
   optimize: boolean // default: false
   server: boolean // default: false
+  mute: boolean // default: false
 }
 ```
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR is a mixed bag of changes but mainly:

- We no longer clone the original component. This process is costly since cloning entire components takes time. We now assume that when a user creates a block, it permanently destroys the original component.
- REGISTRY is now DOM API free and can be imported without consequence
- Components are now hoisted. Any bindings are assumed to be accessible in the component scope

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
