### PR TITLE
Update TypeScript version from 4.9.5 to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "source-map": "^0.7.4",
     "tslib": "^2.5.0",
     "turbo": "^1.8.2",
-    "typescript": "^4.9.5",
+    "typescript": "^5.1.3",
     "unbuild": "^0.7.6",
     "vite": "3.0.0",
     "vite-tsconfig-paths": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,13 +28,13 @@ importers:
         version: 18.14.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.53.0
-        version: 5.53.0(@typescript-eslint/parser@5.53.0)(eslint@8.34.0)(typescript@4.9.5)
+        version: 5.53.0(@typescript-eslint/parser@5.53.0)(eslint@8.34.0)(typescript@5.1.3)
       '@typescript-eslint/parser':
         specifier: ^5.53.0
-        version: 5.53.0(eslint@8.34.0)(typescript@4.9.5)
+        version: 5.53.0(eslint@8.34.0)(typescript@5.1.3)
       '@vercel/style-guide':
         specifier: ^3.0.0
-        version: 3.0.0(@babel/core@7.21.0)(eslint@8.34.0)(prettier@2.8.4)(typescript@4.9.5)
+        version: 3.0.0(@babel/core@7.21.0)(eslint@8.34.0)(prettier@2.8.4)(typescript@5.1.3)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.0.0(vite@3.0.0)
@@ -78,8 +78,8 @@ importers:
         specifier: ^1.8.2
         version: 1.8.2
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.1.3
+        version: 5.1.3
       unbuild:
         specifier: ^0.7.6
         version: 0.7.6
@@ -88,7 +88,7 @@ importers:
         version: 3.0.0
       vite-tsconfig-paths:
         specifier: ^4.2.0
-        version: 4.2.0(typescript@4.9.5)(vite@3.0.0)
+        version: 4.2.0(typescript@5.1.3)(vite@3.0.0)
       vitest:
         specifier: 0.32.0
         version: 0.32.0(jsdom@21.1.0)
@@ -1903,7 +1903,7 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.17.0(@typescript-eslint/parser@5.17.0)(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.17.0(@typescript-eslint/parser@5.17.0)(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1914,23 +1914,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
       '@typescript-eslint/scope-manager': 5.17.0
-      '@typescript-eslint/type-utils': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.34.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.53.0(@typescript-eslint/parser@5.53.0)(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.53.0(@typescript-eslint/parser@5.53.0)(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1941,10 +1941,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.53.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.53.0(eslint@8.34.0)(typescript@5.1.3)
       '@typescript-eslint/scope-manager': 5.53.0
-      '@typescript-eslint/type-utils': 5.53.0(eslint@8.34.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.53.0(eslint@8.34.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.34.0
       grapheme-splitter: 1.0.4
@@ -1952,13 +1952,13 @@ packages:
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.17.0(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.17.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1970,15 +1970,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.17.0
       '@typescript-eslint/types': 5.17.0
-      '@typescript-eslint/typescript-estree': 5.17.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.17.0(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.34.0
-      typescript: 4.9.5
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.53.0(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.53.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1990,10 +1990,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/types': 5.53.0
-      '@typescript-eslint/typescript-estree': 5.53.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.53.0(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.34.0
-      typescript: 4.9.5
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2014,7 +2014,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.53.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.17.0(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.17.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2024,16 +2024,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.34.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.53.0(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.53.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2043,12 +2043,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.53.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.53.0(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.34.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2063,7 +2063,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.17.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.17.0(typescript@5.1.3):
     resolution: {integrity: sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2078,13 +2078,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.53.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.53.0(typescript@5.1.3):
     resolution: {integrity: sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2099,13 +2099,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.17.0(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.17.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2114,7 +2114,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.17.0
       '@typescript-eslint/types': 5.17.0
-      '@typescript-eslint/typescript-estree': 5.17.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.17.0(typescript@5.1.3)
       eslint: 8.34.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.34.0)
@@ -2123,7 +2123,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.53.0(eslint@8.34.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.53.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2133,7 +2133,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/types': 5.53.0
-      '@typescript-eslint/typescript-estree': 5.53.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.53.0(typescript@5.1.3)
       eslint: 8.34.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.34.0)
@@ -2176,7 +2176,7 @@ packages:
       yoga-wasm-web: 0.3.3
     dev: false
 
-  /@vercel/style-guide@3.0.0(@babel/core@7.21.0)(eslint@8.34.0)(prettier@2.8.4)(typescript@4.9.5):
+  /@vercel/style-guide@3.0.0(@babel/core@7.21.0)(eslint@8.34.0)(prettier@2.8.4)(typescript@5.1.3):
     resolution: {integrity: sha512-4hAlUpXrgty3eWOmYuVMjMxhsYaw0wFZAgFNlsrwp5LM6iPcjZXKbhEi3z3QZIJ7Mkixtg0gpYfq9oNzZgEahA==}
     peerDependencies:
       eslint: ^8.12.0
@@ -2185,19 +2185,19 @@ packages:
       '@babel/eslint-parser': 7.17.0(@babel/core@7.21.0)(eslint@8.34.0)
       '@next/eslint-plugin-next': 12.1.2
       '@rushstack/eslint-patch': 1.1.1
-      '@typescript-eslint/eslint-plugin': 5.17.0(@typescript-eslint/parser@5.17.0)(eslint@8.34.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.17.0(@typescript-eslint/parser@5.17.0)(eslint@8.34.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
       eslint: 8.34.0
       eslint-config-prettier: 8.5.0(eslint@8.34.0)
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.25.4)
       eslint-import-resolver-typescript: 2.7.0(eslint-plugin-import@2.25.4)(eslint@8.34.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.34.0)
       eslint-plugin-import: 2.25.4(@typescript-eslint/parser@5.17.0)(eslint-import-resolver-typescript@2.7.0)(eslint@8.34.0)
-      eslint-plugin-jest: 26.1.3(@typescript-eslint/eslint-plugin@5.17.0)(eslint@8.34.0)(typescript@4.9.5)
+      eslint-plugin-jest: 26.1.3(@typescript-eslint/eslint-plugin@5.17.0)(eslint@8.34.0)(typescript@5.1.3)
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.34.0)
       eslint-plugin-react: 7.29.4(eslint@8.34.0)
       eslint-plugin-react-hooks: 4.3.0(eslint@8.34.0)
-      eslint-plugin-testing-library: 5.1.0(eslint@8.34.0)(typescript@4.9.5)
+      eslint-plugin-testing-library: 5.1.0(eslint@8.34.0)(typescript@5.1.3)
       eslint-plugin-tsdoc: 0.2.14
       eslint-plugin-unicorn: 41.0.1(eslint@8.34.0)
       prettier: 2.8.4
@@ -3521,7 +3521,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
       debug: 3.2.7
       eslint: 8.34.0
       eslint-import-resolver-node: 0.3.7
@@ -3551,7 +3551,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.17.0(eslint@8.34.0)(typescript@5.1.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
@@ -3572,7 +3572,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@26.1.3(@typescript-eslint/eslint-plugin@5.17.0)(eslint@8.34.0)(typescript@4.9.5):
+  /eslint-plugin-jest@26.1.3(@typescript-eslint/eslint-plugin@5.17.0)(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-Pju+T7MFpo5VFhFlwrkK/9jRUu18r2iugvgyrWOnnGRaVTFFmFXp+xFJpHyqmjjLmGJPKLeEFLVTAxezkApcpQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3585,8 +3585,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.17.0(@typescript-eslint/parser@5.17.0)(eslint@8.34.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.17.0(@typescript-eslint/parser@5.17.0)(eslint@8.34.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@5.1.3)
       eslint: 8.34.0
     transitivePeerDependencies:
       - supports-color
@@ -3646,13 +3646,13 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
-  /eslint-plugin-testing-library@5.1.0(eslint@8.34.0)(typescript@4.9.5):
+  /eslint-plugin-testing-library@5.1.0(eslint@8.34.0)(typescript@5.1.3):
     resolution: {integrity: sha512-YSNzasJUbyhOTe14ZPygeOBvcPvcaNkwHwrj4vdf+uirr2D32JTDaKi6CP5Os2aWtOcvt4uBSPXp9h5xGoqvWQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.53.0(eslint@8.34.0)(typescript@5.1.3)
       eslint: 8.34.0
     transitivePeerDependencies:
       - supports-color
@@ -7259,7 +7259,7 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
-  /tsconfck@2.1.1(typescript@4.9.5):
+  /tsconfck@2.1.1(typescript@5.1.3):
     resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
     engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
@@ -7269,7 +7269,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.1.3
     dev: true
 
   /tsconfig-paths@3.14.2:
@@ -7288,14 +7288,14 @@ packages:
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsutils@3.21.0(typescript@4.9.5):
+  /tsutils@3.21.0(typescript@5.1.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.1.3
     dev: true
 
   /turbo-darwin-64@1.8.2:
@@ -7417,6 +7417,12 @@ packages:
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.1.3:
+    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
@@ -7718,7 +7724,7 @@ packages:
       - terser
     dev: true
 
-  /vite-tsconfig-paths@4.2.0(typescript@4.9.5)(vite@3.0.0):
+  /vite-tsconfig-paths@4.2.0(typescript@5.1.3)(vite@3.0.0):
     resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
       vite: '*'
@@ -7728,7 +7734,7 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@4.9.5)
+      tsconfck: 2.1.1(typescript@5.1.3)
       vite: 3.0.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR updates the TypeScript version from 4.9.5 to 5.1.3. This change has been made at the turborepo root in the devDependencies, so it should not affect the actual operation. This is just a small maintenance update to keep our development environment up to date.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
