### PR TITLE
Update documentation to resolve Vite plugin order issue

### DIFF
--- a/website/pages/docs/install.mdx
+++ b/website/pages/docs/install.mdx
@@ -89,10 +89,11 @@ Then, add the compiler to your build tool of choice:
     <Tab>
     ```js filename="vite.config.js"
     import million from 'million/compiler';
+    import react from "@vitejs/plugin-react";
     import { defineConfig } from 'vite';
 
     export default defineConfig({
-      plugins: [million.vite()],
+      plugins: [million.vite(), { ...react(), enforce: 'default' }],
     });
     ```
     </Tab>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR updates the documentation to resolve an issue ( #405 ) where the Vite plugin order between MillionJS and React plugin caused the application to fail. The React plugin was modifying the AST before MillionJS could compile the components, changing their structure. By explicitly setting the enforce property to 'default' for the React plugin in the documentation, we ensure that the MillionJS compiler runs first, resolving the issue.

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
