### PR TITLE
fix: allow importing both for and block + flaatten no props

### DIFF
--- a/packages/compiler/react/transform.ts
+++ b/packages/compiler/react/transform.ts
@@ -227,12 +227,12 @@ export const transformComponent = (
 
   // We want to add a __props property for the original call props
   // TODO: refactor this probably
-  dynamics.data.push({
-    id: t.identifier('__props'),
-    value: params?.length
-      ? (params[0] as t.Expression)
-      : t.objectExpression([]),
-  });
+  if (params?.length) {
+    dynamics.data.push({
+      id: t.identifier('__props'),
+      value: params[0] as t.Expression,
+    });
+  }
 
   const holes = dynamics.data.map(({ id }) => id.name);
   const userOptions = callSite.arguments[1] as t.ObjectExpression | undefined;
@@ -326,9 +326,10 @@ export const transformComponent = (
    * const master = (props) => {
    * ```
    */
-
   Component.id = masterComponentId;
-  callSitePath.replaceWith(masterComponentId);
+  callSitePath.replaceWith(
+    dynamics.data.length ? masterComponentId : puppetComponentId,
+  );
 
   // Try to set the display name to something meaningful
   globalPath.insertBefore(

--- a/packages/compiler/react/transform.ts
+++ b/packages/compiler/react/transform.ts
@@ -227,7 +227,7 @@ export const transformComponent = (
 
   // We want to add a __props property for the original call props
   // TODO: refactor this probably
-  if (params?.length) {
+  if (params?.length && t.isExpression(params[0])) {
     dynamics.data.push({
       id: t.identifier('__props'),
       value: params[0] as t.Expression,

--- a/packages/compiler/react/visitor.ts
+++ b/packages/compiler/react/visitor.ts
@@ -70,7 +70,7 @@ export const visitor = (options: Options = {}, isReact = true) => {
     if (
       !t.isImportDeclaration(importDeclaration) ||
       !importDeclaration.source.value.includes('million') ||
-      !importDeclaration.specifiers.some((specifier) => {
+      !importDeclaration.specifiers.every((specifier) => {
         if (!t.isImportSpecifier(specifier)) return false;
         const importedSpecifier = specifier.imported;
         if (!t.isIdentifier(importedSpecifier)) return false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes importing `{ For, block }` not transforming, and removes `__props` when there are no props.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
