### PR TITLE
Docs fix: Installation/Vite - Incorrect enforce type in Vite config

### DIFF
--- a/website/pages/docs/install.mdx
+++ b/website/pages/docs/install.mdx
@@ -93,7 +93,7 @@ Then, add the compiler to your build tool of choice:
     import { defineConfig } from 'vite';
 
     export default defineConfig({
-      plugins: [million.vite(), { ...react(), enforce: 'default' }],
+      plugins: [million.vite(), react() }],
     });
     ```
     </Tab>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [X] Code changes have been tested against prettier, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.

----

The existing suggested enforce type is incorrect as the latest Vite does not support default type and only supports `"pre"` or `"post"`.

<img width="1246" alt="image" src="https://github.com/aidenybai/million/assets/963490/ad3a2d97-546c-4159-81f2-044386dce9e9">

This pull request changes it to use defaults instead, similar to the examples later in the docs 

https://github.com/aidenybai/million/blob/main/website/components/box.tsx#L108
![image](https://github.com/aidenybai/million/assets/963490/dce08953-efaf-48a5-8f29-8df879f5b3fc)


Both the website and apps with the new config work fine

<img width="931" alt="image" src="https://github.com/aidenybai/million/assets/963490/888cb2d7-f8d6-4bd1-9e60-a305f3586646">






