### PR TITLE
fix(preact): avoid importing react in the built bundle

### DIFF
--- a/packages/preact-server/index.ts
+++ b/packages/preact-server/index.ts
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useEffect, useReducer } from 'preact/hooks';
-import { RENDER_SCOPE } from '../react/constants';
+import { RENDER_SCOPE } from '../preact/constants';
 import type { ComponentProps, ComponentType, VNode } from 'preact';
 import type * as MillionModule from '../preact';
 

--- a/packages/preact/block.ts
+++ b/packages/preact/block.ts
@@ -7,9 +7,8 @@ import {
 } from '../million/block';
 import { Map$, MapGet$, MapHas$, MapSet$ } from '../million/constants';
 import { queueMicrotask$ } from '../million/dom';
-import { Effect, RENDER_SCOPE } from '../react/constants';
-import { processProps } from '../react/utils';
-import { unwrap } from './utils';
+import { Effect, RENDER_SCOPE } from './constants';
+import { unwrap, processProps } from './utils';
 import type { MillionProps, Options } from '../types';
 import type { Props } from '../million';
 import type { ComponentType, VNode } from 'preact';

--- a/packages/preact/constants.ts
+++ b/packages/preact/constants.ts
@@ -1,13 +1,5 @@
-import { useEffect } from 'preact/hooks';
-import type { ComponentType, FunctionComponent as FC } from 'preact';
+import type { FunctionComponent as FC } from 'preact';
 
 export const RENDER_SCOPE = 'slot';
 export const SVG_RENDER_SCOPE = 'g';
 export const REACT_ROOT = '__react_root';
-
-export const Effect: FC<{ effect: () => void }> = ({ effect }) => {
-  useEffect(effect, []);
-  return null;
-};
-
-export const REGISTRY = new Map<ComponentType, any>();

--- a/packages/preact/constants.ts
+++ b/packages/preact/constants.ts
@@ -1,5 +1,3 @@
-import type { FunctionComponent as FC } from 'preact';
-
 export const RENDER_SCOPE = 'slot';
 export const SVG_RENDER_SCOPE = 'g';
 export const REACT_ROOT = '__react_root';

--- a/packages/preact/constants.ts
+++ b/packages/preact/constants.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'preact/hooks';
+import type { ComponentType, FunctionComponent as FC } from 'preact';
+
+export const RENDER_SCOPE = 'slot';
+export const SVG_RENDER_SCOPE = 'g';
+export const REACT_ROOT = '__react_root';
+
+export const Effect: FC<{ effect: () => void }> = ({ effect }) => {
+  useEffect(effect, []);
+  return null;
+};
+
+export const REGISTRY = new Map<ComponentType, any>();

--- a/packages/preact/for.ts
+++ b/packages/preact/for.ts
@@ -7,7 +7,7 @@ import { queueMicrotask$ } from '../million/dom';
 import { REGISTRY } from './block';
 import { renderPreactScope } from './utils';
 import { RENDER_SCOPE } from './constants';
-import type { Props, Block } from '../million';
+import type { Block } from '../million';
 import type { ArrayCache, MillionArrayProps, MillionProps } from '../types';
 
 export const For = <T>({ each, children }: MillionArrayProps<T>) => {

--- a/packages/preact/for.ts
+++ b/packages/preact/for.ts
@@ -4,9 +4,9 @@ import { arrayMount$, arrayPatch$ } from '../million/array';
 import { mapArray, block as createBlock } from '../million';
 import { MapSet$, MapHas$, MapGet$ } from '../million/constants';
 import { queueMicrotask$ } from '../million/dom';
-import { RENDER_SCOPE } from '../react/constants';
 import { REGISTRY } from './block';
 import { renderPreactScope } from './utils';
+import { RENDER_SCOPE } from './constants';
 import type { Props } from '../million';
 import type { ArrayCache, MillionArrayProps } from '../types';
 

--- a/packages/preact/utils.ts
+++ b/packages/preact/utils.ts
@@ -2,9 +2,7 @@ import { render, Fragment, isValidElement } from 'preact';
 import { RENDER_SCOPE } from './constants';
 import type {
   VNode as PreactNode,
-  ComponentChild,
   ComponentProps,
-  ComponentChildren,
 } from 'preact';
 import type { VNode } from '../million';
 

--- a/packages/preact/utils.ts
+++ b/packages/preact/utils.ts
@@ -1,11 +1,27 @@
-import { render, Fragment } from 'preact';
-import { RENDER_SCOPE } from '../react/constants';
+import { render, Fragment, isValidElement } from 'preact';
+import { RENDER_SCOPE } from './constants';
 import type {
   VNode as PreactNode,
   ComponentChild,
+  ComponentProps,
   ComponentChildren,
 } from 'preact';
 import type { VNode } from '../million';
+
+export const processProps = (props: ComponentProps<any>) => {
+  const processedProps: ComponentProps<any> = {};
+
+  for (const key in props) {
+    const value = props[key];
+    if (isValidElement(value)) {
+      processedProps[key] = renderPreactScope(value);
+      continue;
+    }
+    processedProps[key] = props[key];
+  }
+
+  return processedProps;
+};
 
 export const renderPreactScope = (vnode: PreactNode) => {
   return (el: HTMLElement | null) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

fixes https://github.com/aidenybai/million/issues/461

This change "vendors" a few things from `/react` to avoid `unbuild` producing empty imports, the empty imports are a consequence of React not utilising `sideEffects: false`, rollup can never know whether or not it's safe to remove these imports. We could write a plugin that removes empty imports, however it looked safer to me to just import stuff from Preact instead. Happy to discuss this where needed.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
