### PR TITLE
Ensure `css` TaggedTemplateExpression is static in isStatic function

### DIFF
--- a/packages/compiler/react/utils.ts
+++ b/packages/compiler/react/utils.ts
@@ -134,6 +134,7 @@ export const isStatic = (node: t.Node) => {
   if (
     t.isTaggedTemplateExpression(node) &&
     t.isIdentifier(node.tag) &&
+    node.quasi.expressions.length === 0 &&
     node.tag.name === 'css'
   ) {
     return true;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR modifies the `isStatic` function to ensure that `css` TaggedTemplateExpressions are indeed static. Previously, the function would return true for any 'css' TaggedTemplateExpression, regardless of whether it contained interpolations or not.

The function now checks that the quasi.expressions array is empty, indicating that the TaggedTemplateExpression has no interpolations.

This fix was made in response to a commit ([a588ead](https://github.com/aidenybai/million/commit/a588ead96cf372faf612452a6009a1424bc18259)) titled 'hotfix: partial emotion support', suggesting that complete static verification was required.


**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
