### PR TITLE
fix: only log the inital helper  once

### DIFF
--- a/packages/compiler/plugin.ts
+++ b/packages/compiler/plugin.ts
@@ -27,37 +27,37 @@ export interface Options {
 }
 
 export const unplugin = createUnplugin((options: Options = {}) => {
+  const comment = `${
+    styleLinks(
+      'Schedule a call if you need help: https://million.dev/hotline. To disable help messages, set the "mute" option to true.',
+    ) +
+    styleCommentMessage(
+      '\nThere is no guarantee that features in beta will be completely production ready, so here be dragons.',
+    )
+  }\n\n${blue('💡 TIP')}: Use ${styleCommentMessage(
+    '// million-ignore',
+  )} to skip over problematic components.`;
+
+  if (options.optimize) {
+    // eslint-disable-next-line no-console
+    console.log(
+      stylePrimaryMessage(
+        `Optimizing compiler is enabled ✓ (beta)`,
+        comment,
+      ),
+    );
+  }
+
+  if (options.auto) {
+    // eslint-disable-next-line no-console
+    console.log(
+      stylePrimaryMessage(`Automatic mode is enabled ✓ (beta)`, comment),
+    );
+  }
+  
   return {
     enforce: 'pre',
     name: 'million',
-    buildStart() {
-      const comment = `${
-        styleLinks(
-          'Schedule a call if you need help: https://million.dev/hotline. To disable help messages, set the "mute" option to true.',
-        ) +
-        styleCommentMessage(
-          '\nThere is no guarantee that features in beta will be completely production ready, so here be dragons.',
-        )
-      }\n\n${blue('💡 TIP')}: Use ${styleCommentMessage(
-        '// million-ignore',
-      )} to skip over problematic components.`;
-
-      if (options.optimize) {
-        // eslint-disable-next-line no-console
-        console.log(
-          stylePrimaryMessage(
-            `Optimizing compiler is enabled ✓ (beta)`,
-            comment,
-          ),
-        );
-      }
-      if (options.auto) {
-        // eslint-disable-next-line no-console
-        console.log(
-          stylePrimaryMessage(`Automatic mode is enabled ✓ (beta)`, comment),
-        );
-      }
-    },
     transformInclude(id: string) {
       return /\.[jt]sx$/.test(id);
     },


### PR DESCRIPTION
this make the initial helper log to log once. It could be annoying showing similar text every time it run build.