### PR TITLE
Fix 529: Background screen flash on reload

### DIFF
--- a/website/styles/global.css
+++ b/website/styles/global.css
@@ -7,6 +7,14 @@ body {
   font-family: Space Grotesk, -apple-system, BlinkMacSystemFont, avenir next,
     avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto,
     arial, sans-serif;
+  color: #000;
+  background: #fff;
+}
+
+[data-theme='dark'],
+[data-theme='dark'] body {
+  color: #fff;
+  background: #000;
 }
 
 #hero {

--- a/website/styles/global.css
+++ b/website/styles/global.css
@@ -7,14 +7,14 @@ body {
   font-family: Space Grotesk, -apple-system, BlinkMacSystemFont, avenir next,
     avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto,
     arial, sans-serif;
-  color: #000;
+  color: #111;
   background: #fff;
 }
 
 [data-theme='dark'],
 [data-theme='dark'] body {
   color: #fff;
-  background: #000;
+  background: #111;
 }
 
 #hero {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I followed instructions from https://github.com/pacocoursey/next-themes#without-css-variables to fix flashing. Now instead of seeing a quick white screen flash into your eyes when you open the site, the background will stay dark.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
