### PR TITLE
fix(compiler): Directly import babel plugins

### DIFF
--- a/packages/compiler/plugin.ts
+++ b/packages/compiler/plugin.ts
@@ -1,6 +1,8 @@
 import { declare } from '@babel/helper-plugin-utils';
 import { createUnplugin } from 'unplugin';
 import { transformAsync } from '@babel/core';
+import pluginSyntaxJsx from '@babel/plugin-syntax-jsx';
+import pluginSyntaxTypescript from '@babel/plugin-syntax-typescript';
 import { blue } from 'kleur/colors';
 import { visitor as legacyVdomVisitor } from './vdom';
 import {
@@ -65,18 +67,19 @@ export const unplugin = createUnplugin((options: Options = {}) => {
       return /\.[jt]sx$/.test(id);
     },
     async transform(code: string, id: string) {
-      const isTSX = id.endsWith('.tsx');
-
       options._file = id;
 
-      const plugins = normalizePlugins([
-        '@babel/plugin-syntax-jsx',
-        isTSX && [
-          '@babel/plugin-syntax-typescript',
+      const plugins: PluginItem[] = [[pluginSyntaxJsx]];
+
+      const isTSX = id.endsWith('.tsx');
+      if (isTSX) {
+        plugins.push([
+          pluginSyntaxTypescript,
           { allExtensions: true, isTSX: true },
-        ],
-        [babelPlugin, options],
-      ]);
+        ]);
+      }
+
+      plugins.push([babelPlugin, options]);
 
       const result = await transformAsync(code, { plugins, filename: id });
 


### PR DESCRIPTION
fixes https://github.com/aidenybai/million/issues/532

Instead of relying on the string path for the plugin let's import the babel plugin directly. This should hopefully be more robust.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
