### PR TITLE
Extend JSX Binary Operations Evaluation

### DIFF
--- a/packages/compiler/react/evaluator.ts
+++ b/packages/compiler/react/evaluator.ts
@@ -160,67 +160,10 @@ export const evaluateAstNode = (
   }
 
   if (t.isBinaryExpression(ast)) {
-    if (ast.operator === '+') {
-      const left = evaluateAstNode(ast.left, staticContext) as number;
-      const right = evaluateAstNode(ast.right, staticContext) as number;
-      return left + right;
-    } else if (ast.operator === '-') {
-      return (
-        evaluateAstNode(ast.left, staticContext) -
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '*') {
-      return (
-        evaluateAstNode(ast.left, staticContext) *
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '/') {
-      return (
-        evaluateAstNode(ast.left, staticContext) /
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '<') {
-      return (
-        evaluateAstNode(ast.left, staticContext) <
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '>') {
-      return (
-        evaluateAstNode(ast.left, staticContext) >
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '<=') {
-      return (
-        evaluateAstNode(ast.left, staticContext) <=
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '>=') {
-      return (
-        evaluateAstNode(ast.left, staticContext) >=
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '==') {
-      return (
-        // eslint-disable-next-line eqeqeq
-        evaluateAstNode(ast.left, staticContext) ==
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '!=') {
-      return (
-        // eslint-disable-next-line eqeqeq
-        evaluateAstNode(ast.left, staticContext) !=
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '===') {
-      return (
-        evaluateAstNode(ast.left, staticContext) ===
-        evaluateAstNode(ast.right, staticContext)
-      );
-    } else if (ast.operator === '!==') {
-      return (
-        evaluateAstNode(ast.left, staticContext) !==
-        evaluateAstNode(ast.right, staticContext)
-      );
+    const left = evaluateAstNode(ast.left, staticContext);
+    const right = evaluateAstNode(ast.right, staticContext);
+    if (typeof left === 'number' && typeof right === 'number') {
+      return evaluateBinaryExpression(left, right, ast.operator);
     }
   }
 
@@ -252,3 +195,40 @@ export const valueToAst = (value: unknown) => {
       throw new Error(`Cannot convert value to AST: ${String(value)}`);
   }
 };
+
+function evaluateBinaryExpression(
+  left: number,
+  right: number,
+  operator: t.BinaryExpression['operator'],
+): any {
+  switch (operator) {
+    case '+':
+      return left + right;
+    case '-':
+      return left - right;
+    case '*':
+      return left * right;
+    case '/':
+      return left / right;
+    case '<':
+      return left < right;
+    case '>':
+      return left > right;
+    case '<=':
+      return left <= right;
+    case '>=':
+      return left >= right;
+    case '==':
+      // eslint-disable-next-line eqeqeq
+      return left == right;
+    case '!=':
+      // eslint-disable-next-line eqeqeq
+      return left != right;
+    case '===':
+      return left === right;
+    case '!==':
+      return left !== right;
+    default:
+      return undefined;
+  }
+}

--- a/packages/compiler/react/evaluator.ts
+++ b/packages/compiler/react/evaluator.ts
@@ -179,6 +179,48 @@ export const evaluateAstNode = (
         evaluateAstNode(ast.left, staticContext) /
         evaluateAstNode(ast.right, staticContext)
       );
+    } else if (ast.operator === '<') {
+      return (
+        evaluateAstNode(ast.left, staticContext) <
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '>') {
+      return (
+        evaluateAstNode(ast.left, staticContext) >
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '<=') {
+      return (
+        evaluateAstNode(ast.left, staticContext) <=
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '>=') {
+      return (
+        evaluateAstNode(ast.left, staticContext) >=
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '==') {
+      return (
+        // eslint-disable-next-line eqeqeq
+        evaluateAstNode(ast.left, staticContext) ==
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '!=') {
+      return (
+        // eslint-disable-next-line eqeqeq
+        evaluateAstNode(ast.left, staticContext) !=
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '===') {
+      return (
+        evaluateAstNode(ast.left, staticContext) ===
+        evaluateAstNode(ast.right, staticContext)
+      );
+    } else if (ast.operator === '!==') {
+      return (
+        evaluateAstNode(ast.left, staticContext) !==
+        evaluateAstNode(ast.right, staticContext)
+      );
     }
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR extends the existing JSX binary operations evaluation functionality.
### Changes:
- Added evaluation support for relational operators (`<`, `>`, `<=`, `>=`).
- Added evaluation support for equality operators (`==`, `!=`, `===`, `!==`).


**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
