### PR TITLE
fix: remove needless spread in transform

### DIFF
--- a/packages/compiler/react/transform.ts
+++ b/packages/compiler/react/transform.ts
@@ -345,11 +345,10 @@ export const transformComponent = (
 
   if (data.length) {
     jsxPath.insertBefore(
-      t.variableDeclaration('const', [
-        ...data.map(({ id, value }) => {
+      t.variableDeclaration('const', data.map(({ id, value }) => {
           return t.variableDeclarator(id, value);
         }),
-      ]),
+      ),
     );
   }
 

--- a/packages/compiler/react/transform.ts
+++ b/packages/compiler/react/transform.ts
@@ -345,7 +345,9 @@ export const transformComponent = (
 
   if (data.length) {
     jsxPath.insertBefore(
-      t.variableDeclaration('const', data.map(({ id, value }) => {
+      t.variableDeclaration(
+        'const',
+        data.map(({ id, value }) => {
           return t.variableDeclarator(id, value);
         }),
       ),


### PR DESCRIPTION
I removed needless `spread`, because `map` already created new array.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
