### PR TITLE
Fix plurality of "users" in status

### DIFF
--- a/website/components/extra-content.tsx
+++ b/website/components/extra-content.tsx
@@ -17,6 +17,7 @@ export function ExtraContent() {
 export function Status() {
   const [, forceUpdate] = useState({});
   const count = getCount();
+  const userString = count > 1 ? "users" : "user";
   // useEffect(() => {
   //   const interval = setInterval(() => {
   //     forceUpdate({});
@@ -29,7 +30,7 @@ export function Status() {
         <div className="animate-ping absolute inline-flex h-full w-full rounded-full bg-purple-400 opacity-75"></div>
         <div className="relative inline-flex rounded-full h-3 w-3 bg-purple-500"></div>
       </div>
-      {count} users connected.
+      {count} {userString} connected.
     </div>
   );
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Simple fix: when there is only a single user online on a page, use "user" instead of "users" so we don't end up with "1 users connected"

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
