### PR TITLE
Fix for Auto Response Action

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -3,7 +3,7 @@ name: Automated Responses
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
As per this [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) `pull_request_target` is used for: 

> This event allows your workflow to do things like label or comment on pull requests from forks.