### PR TITLE
fix/#680/input value does not update on screen

### DIFF
--- a/packages/million/dom.ts
+++ b/packages/million/dom.ts
@@ -227,4 +227,13 @@ export const setAttribute = (
   } else {
     removeAttribute$.call(el, name);
   }
+
+  const isInput = el instanceof HTMLInputElement;
+  const isSelect = el instanceof HTMLSelectElement;
+  const isTextArea = el instanceof HTMLTextAreaElement;
+
+  if (name === 'value' && (isInput || isSelect || isTextArea)) {
+    setAttribute$.call(el, name, String(value));
+    el.value = value as string;
+  }
 };

--- a/test/block.test.ts
+++ b/test/block.test.ts
@@ -101,4 +101,31 @@ describe.concurrent('block', () => {
       '<div><h1>Hello</h1> World<p title="baz" style="margin: 1px;" class="bar"></p></div>',
     );
   });
+
+  it('should clear input inside block if the value is empty', ({ expect }) => {
+    const block = createBlock((props?: MillionProps) => {
+      return {
+        type: 'div',
+        props: {
+          children: [
+            {
+              type: 'input',
+              props: {
+                value: props?.foo,
+              },
+            },
+          ],
+        },
+      };
+    });
+
+    const main = block({ foo: 'foo' });
+
+    main.m();
+    expect(main.l?.outerHTML).toEqual('<div><input value="foo"></div>');
+
+    main.p(block({ foo: '' }));
+
+    expect(main.l?.outerHTML).toEqual('<div><input value=""></div>');
+  })
 });

--- a/test/block.test.ts
+++ b/test/block.test.ts
@@ -127,5 +127,5 @@ describe.concurrent('block', () => {
     main.p(block({ foo: '' }));
 
     expect(main.l?.outerHTML).toEqual('<div><input value=""></div>');
-  })
+  });
 });


### PR DESCRIPTION
- test: ensure that value is being cleaned
- fix: set value explicitly to input, select, or text area elements

**Please describe the changes this PR makes and why it should be merged:**
This fixes #680. The issue is that we changed the attribute via `setAttribute, ' which does not re-render/update the DOM value after it was already set (which is different from setting explicitly using `element.value = 'something'`). This is mentioned on [MDN's setAttribute documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#gecko_notes)
> Using `setAttribute()` to modify certain attributes, most notably value in XUL, works inconsistently, as the attribute 
specifies the default value. To access or modify the current values, you should use the properties. For example, use 
Element.value instead of Element.setAttribute().

Here is a JSFiddle showing the behavior happening: https://jsfiddle.net/hybrk97u/

This fix introduces a manual value set for `HTMLInputElement`, `HTMLSelectElement`, and `HTMLTextAreaElement`. These are the only elements that suffer from this issue from what I found here.

**Status**

- [X] Code changes have been tested against prettier, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [X] This PR changes the internal workings with no modifications to the external API (bug fixes, performance 
improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

/claim #680
