### PR TITLE
fix(website): youtube embed component mobile sizing

### DIFF
--- a/website/pages/blog/virtual-dom.mdx
+++ b/website/pages/blog/virtual-dom.mdx
@@ -20,7 +20,6 @@ import { CarbonAds } from '../../components/ad';
   </a>
 </div>
 
-
 <div className="flex flex-col items-center gap-4">
 
 # Virtual DOM: Back in Block
@@ -37,8 +36,12 @@ import { CarbonAds } from '../../components/ad';
 
 <br />
 
-<div className="flex justify-center">
-  <YouTube videoId="VkezQMb1DHw" opts={{ start: 73 }} />
+<div className="lg:w-7/12 text-center mx-auto flex justify-center">
+  <YouTube
+    className="youtubeContainer"
+    videoId="VkezQMb1DHw"
+    opts={{ start: 73 }}
+  />
 </div>
 
 ---

--- a/website/styles/global.css
+++ b/website/styles/global.css
@@ -676,10 +676,8 @@ li > a {
 .youtubeContainer {
   position: relative;
   width: 100%;
-  height: 0;
-  padding-bottom: 56.25%;
+  aspect-ratio: 16 / 9;
   overflow: hidden;
-  margin-bottom: 50px;
 }
 
 .youtubeContainer iframe {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The YouTube embed on the "Back in Block" blog post looks broken on mobile:

<img width="580" alt="Screenshot 2023-12-27 at 4 46 55 PM" src="https://github.com/aidenybai/million/assets/14811170/6b80bd18-d93e-47b1-924b-deac76a123d5">

This is actually already fixed on the `/ai` page. This PR brings that fix over to this blog post.

<img width="254" alt="Screenshot 2023-12-27 at 4 45 49 PM" src="https://github.com/aidenybai/million/assets/14811170/08242dfe-2f9e-42f3-a08d-bb3439a7673f">

It also uses the `aspect-ratio` CSS property, which is now supported in all major browsers.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
