### PR TITLE
chore: updated cli docs url

### DIFF
--- a/packages/compiler/react/utils.ts
+++ b/packages/compiler/react/utils.ts
@@ -145,7 +145,7 @@ export const warn = (
     err.message,
     '\n',
     styleCommentMessage(
-      `Check out the Rules of Blocks: https://million.dev/docs/rules. Enable the "mute" option to disable this message.`,
+      `Check out the Rules of Blocks: https://million.dev/docs/manual-mode/block#rules-of-blocks. Enable the "mute" option to disable this message.`,
     ),
     '\n',
   );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the current cli, the warning message for following some rules has a link to the wrong URL [](https://million.dev/docs/rules) so i updated it to the correct URL [](https://million.dev/docs/manual-mode/block#rules-of-blocks)

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
