### PR TITLE
docs: fix 'cooresponding'/'corresponding' typo

### DIFF
--- a/packages/million/block.ts
+++ b/packages/million/block.ts
@@ -225,7 +225,7 @@ export class Block extends AbstractBlock {
         if (edit.t & ChildFlag) {
           if (oldValue instanceof AbstractBlock) {
             // Remember! If we find a block inside a child, we need to locate
-            // the cooresponding block in the new props and patch it.
+            // the corresponding block in the new props and patch it.
             const firstEdit = newBlock.e?.[i]?.e[k] as EditChild;
             const newChildBlock = newBlock.d[firstEdit.h];
             oldValue.p(newChildBlock);


### PR DESCRIPTION
A small typo fix discovered on stream with @tobySolutions 🙂 

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- ~[ ] This PR changes the codebase~
  - ~[ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)~
  - ~[ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)~
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
