### PR TITLE
feat(i18n): add minimal `i18n` configs for docs

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/default -- Next.js requires default export
 import nextra from 'nextra';
 
 const withNextra = nextra({
@@ -12,6 +11,12 @@ const withNextra = nextra({
  */
 const nextConfig = {
   transpilePackages: ['react-tweet'],
+  i18n: {
+    locales: ['en', 'fr', 'de', 'es'],
+    defaultLocale: 'en',
+    localeDetection: true,
+  },
+  trailingSlash: true,
 };
 
 // eslint-disable-next-line import/no-default-export  -- Next.js requires default export

--- a/website/pages/docs/_meta.fr.json
+++ b/website/pages/docs/_meta.fr.json
@@ -1,0 +1,7 @@
+{
+  "index": "Introduction",
+  "install": "Installation",
+  "automatic": "Mode Automatique",
+  "manual-mode": "Mode Manuel",
+  "internals": "Internals"
+}

--- a/website/pages/docs/automatic.fr.mdx
+++ b/website/pages/docs/automatic.fr.mdx
@@ -1,0 +1,207 @@
+---
+title: 'Mode Automatique'
+description: 'Comment utiliser le mode automatique'
+---
+
+import { Callout, Tab, Tabs } from 'nextra-theme-docs';
+
+# Mode Automatique
+
+Million.js uses Automatic Mode out of the box if you installed via CLI. This optimizes your React components, improving speed without any major code changes. This is the recommended way to use Million.js.
+
+### Personnalisations Avancees
+
+Automatic mode provides customization options:
+
+- `threshold`: What is used to determine whether a component should be converted to Million.js.
+  When the threshold increases, fewer components will be optimized, and vice versa.
+- `skip`: An array of identifiers to indicate if a component should be skipped. You can add hook or variable names, function names, etc.
+
+The `auto` object lets you configure options beyond the default ones set during installation:
+
+```js
+auto: {
+  threshold: 0.05, // default: 0.1,
+  skip: ['useBadHook', /badVariable/g], // default []
+}
+```
+
+<Tabs items={['Next.js', 'Astro', 'Gatsby', 'Vite', 'Remix', 'Create React App', 'Webpack', 'Rollup']} storageKey="selected-bundler-compiler">
+<Tab>
+```js filename="next.config.mjs"
+import million from 'million/compiler';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+   reactStrictMode: true,
+};
+
+const millionConfig = {
+  auto: {
+    threshold: 0.05, // default: 0.1,
+    skip: ['useBadHook', /badVariable/g], // default []
+    // if you're using RSC: auto: { rsc: true },
+  }
+}
+
+export default million.next(nextConfig, millionConfig);
+```
+</Tab>
+
+<Tab>
+```js filename="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import million from "million/compiler";
+
+export default defineConfig({
+  vite: {
+    plugins: [
+      million.vite({
+        mode: "react",
+        server: true,
+        auto: {
+          threshold: 0.05,
+          skip: ["useBadHook", /badVariable/g],
+        },
+      }),
+    ],
+  },
+});
+```
+</Tab>
+
+<Tab>
+```js filename="gatsby-node.js"
+const million = require("million/compiler");
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    plugins: [
+      million.webpack({
+        mode: "react",
+        server: true,
+        auto: {
+          threshold: 0.05,
+          skip: ["useBadHook", /badVariable/g],
+        },
+      }),
+    ],
+  });
+};
+```
+</Tab>
+
+<Tab>
+```js filename="vite.config.js"
+import million from "million/compiler";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    million.vite({
+      auto: {
+        threshold: 0.05,
+        skip: ["useBadHook", /badVariable/g],
+      },
+    }),
+    react(),
+  ],
+});
+```
+</Tab>
+
+<Tab>
+```js filename="vite.config.js"
+import { unstable_vitePlugin as remix } from "@remix-run/dev";
+import million from "million/compiler";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    million.vite({
+      auto: {
+        threshold: 0.05,
+        skip: ["useBadHook", /badVariable/g],
+      },
+    }),
+    remix(),
+  ],
+});
+```
+</Tab>
+
+<Tab>
+<Callout type="warning">
+  If you are using a [Create React App (CRA)](https://create-react-app.dev/) Setup, you will need to [configure Craco](https://craco.js.org/docs/getting-started/) before proceeding.
+</Callout>
+
+```js filename="craco.config.js"
+const million = require("million/compiler");
+
+module.exports = {
+  webpack: {
+    plugins: {
+      add: [
+        million.webpack({
+          auto: {
+            threshold: 0.05,
+            skip: ["useBadHook", /badVariable/g],
+          },
+        }),
+      ],
+    },
+  },
+};
+```
+</Tab>
+
+<Tab>
+```js filename="webpack.config.js"
+const million = require("million/compiler");
+module.exports = {
+  plugins: [
+    million.webpack({
+      auto: {
+        threshold: 0.05,
+        skip: ["useBadHook", /badVariable/g],
+      },
+    }),
+  ],
+};
+```
+</Tab>
+
+<Tab>
+```js filename="rollup.config.js"
+import million from "million/compiler";
+
+export default {
+  plugins: [
+    million.rollup({
+      auto: {
+        threshold: 0.05,
+        skip: ["useBadHook", /badVariable/g],
+      },
+    }),
+  ],
+};
+```
+</Tab>
+
+</Tabs>
+
+### Ignoring components
+
+If you encounter an error with a component during the Million.js runtime, it can be skipped using the `// million-ignore` comment.
+
+```js
+// million-ignore
+function App() {
+  return ...
+}
+````
+
+### Muting help messages
+
+To avoid seeing help messages, you can pass the `mute: true{:js}` option to the compiler inside the `auto` object.

--- a/website/pages/docs/index.fr.mdx
+++ b/website/pages/docs/index.fr.mdx
@@ -1,0 +1,65 @@
+import { Disclosures } from '../../components/home/faq';
+import { Callout, Tab, Tabs } from 'nextra-theme-docs';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+
+export const Demo = dynamic(() =>
+  import('../../components/demo').then((mod) => mod.Demo),
+);
+
+# Introduction
+
+**Million.js** is a fast and lightweight (`<4kb`) virtual DOM that can improve [React's speed by up to 70%](https://krausest.github.io/js-framework-benchmark/current.html).
+With a fine-tuned, optimized virtual DOM, Million.js can have your React components running at the speed of raw JavaScript.
+
+## Configurer en quelques secondes
+
+The Million.js CLI will automatically install the package and configure your project for you.
+
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']} storageKey="selected-manager">
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  npx million@latest
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  pnpx million@latest
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  yarn add million@latest
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  bunx million@latest
+  ```
+  </Tab>
+</Tabs>
+
+<Callout type="info">
+  Million.js is compatible with React 16 and above. If you're using an older
+  version of React, you'll need to upgrade first.
+</Callout>
+
+That's it! Your project is now running on Million.js 🎉
+
+## Million.js vs. React
+
+The following is a comprehensive demo using [key-based
+rendering](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)
+to show how Million.js performance compares to React.
+
+<br />
+
+<Demo />
+
+## Any questions?
+
+If you have any questions or need support, please feel free to ask them in [Discord](https://million.dev/chat) or submit an issue on [GitHub](https://github.com/aidenybai/million).

--- a/website/pages/docs/install.fr.mdx
+++ b/website/pages/docs/install.fr.mdx
@@ -1,0 +1,355 @@
+---
+title: 'Installation'
+description: 'Comment installer Million.js sur votre projet React'
+---
+
+import { Callout, Tabs, Tab, Steps } from 'nextra-theme-docs';
+
+# Installation
+
+Million.js assumes that you have an existing React project. To learn about how to create a React app, please see [React's documentation](https://react.dev).
+
+
+### Traduction Franaçaise
+
+## Installer via la CLI
+
+The Million.js CLI will automatically install the package and configure votre projet pour vous.
+
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']} storageKey="selected-manager">
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  npx million@latest
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  pnpx million@latest
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  yarn add million@latest
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  bunx million@latest
+  ```
+  </Tab>
+</Tabs>
+
+
+<Callout type="info">
+  Million.js is compatible with React 16 and above. If you're using an older
+  version of React, you'll need to upgrade first.
+</Callout>
+
+That's it! Your project is now running on Million.js 🎉
+
+## Install manually
+
+If you have issues [installing via the CLI](#install-via-cli), or you have a custom setup, you can
+install Million.js manually.
+
+Notice that there are two modes you can choose: **Automatic** and **Manual**:
+
+- **Automatic mode** will automatically configure, analyze, and optimize your project for you.
+This is the recommended mode.
+
+- **Manual mode** will require you to write code to [optimize certain parts of
+your project](/docs/manual-mode/manual-mode). This mode is recommended for advanced users who want to have more control over their project.
+
+<Tabs items={['Automatic', 'Manual']} storageKey="mode">
+
+<Tab>
+
+<Steps>
+
+### Install Million.js
+
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']} storageKey="selected-pkg-manager">
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  npm install million
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  pnpm install million
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  yarn add million
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  bun add million
+  ```
+  </Tab>
+</Tabs>
+
+### Add the compiler to your application
+
+<Tabs items={['Next.js', 'Astro', 'Gatsby', 'Vite','Remix', 'Create React App', 'Webpack', 'Rollup']} storageKey="selected-bundler-compiler">
+<Tab>
+Million.js is supported within the `/app` ("use client" components only) and `/pages`
+
+```js filename="next.config.mjs"
+import million from "million/compiler";
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+const millionConfig = {
+  auto: true,// if you're using RSC: auto: { rsc: true },
+};
+
+export default million.next(nextConfig, millionConfig);
+```
+</Tab>
+
+<Tab>
+```js filename="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import million from "million/compiler";
+
+export default defineConfig({
+   vite: {
+     plugins: [million.vite({ mode: "react", server: true, auto: true })],
+   },
+});
+```
+</Tab>
+
+<Tab>
+```js filename="gatsby-node.js"
+const million = require("million/compiler");
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    plugins: [million.webpack({ mode: "react", server: true, auto: true })],
+  });
+};
+```
+</Tab>
+
+<Tab>
+```js filename="vite.config.js"
+import million from "million/compiler";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [million.vite({ auto: true }), react()],
+});
+```
+</Tab>
+
+<Tab>
+```js filename="vite.config.js"
+import { unstable_vitePlugin as remix } from "@remix-run/dev";
+import million from "million/compiler";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [million.vite({ auto: true }), remix()],
+});
+```
+</Tab>
+
+<Tab>
+  <Callout type="warning">
+    If you are using a [Create React App (CRA)](https://create-react-app.dev/) Setup, you will need to [configure Craco](https://craco.js.org/docs/getting-started/) before proceeding.
+  </Callout>
+
+```js filename="craco.config.js"
+const million = require("million/compiler");
+
+module.exports = {
+  webpack: {
+    plugins: { add: [million.webpack({ auto: true })] },
+  },
+};
+```
+</Tab>
+
+<Tab>
+```js filename="webpack.config.js"
+const million = require("million/compiler");
+module.exports = {
+  plugins: [million.webpack({ auto: true })],
+};
+```
+</Tab>
+
+<Tab>
+```js filename="rollup.config.js"
+import million from "million/compiler";
+
+export default {
+  plugins: [million.rollup({ auto: true })],
+};
+```
+</Tab>
+</Tabs>
+
+</Steps>
+</Tab>
+
+
+
+<Tab>
+
+<Steps>
+
+### Install Million.js
+
+
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']} storageKey="selected-pkg-manager">
+{/* prettier-ignore */}
+<Tab>
+```bash copy
+npm install million
+```
+
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  pnpm install million
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  yarn add million
+  ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+  ```bash copy
+  bun add million
+  ```
+  </Tab>
+</Tabs>
+
+### Add the compiler to your application
+
+<Tabs items={['Next.js', 'Astro', 'Gatsby', 'Vite', 'Remix', 'Create React App', 'Webpack', 'Rollup']} storageKey="selected-bundler-compiler">
+<Tab>
+Million.js is supported within the `/app` ("use client" components only) and `/pages`
+
+```js filename="next.config.mjs"
+import million from "million/compiler";
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default million.next(nextConfig);
+```
+</Tab>
+
+<Tab>
+```js filename="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import million from "million/compiler";
+
+export default defineConfig({
+  vite: {
+    plugins: [million.vite({ mode: "react", server: true })],
+  },
+});
+```
+</Tab>
+
+<Tab>
+```js filename="gatsby-node.js"
+const million = require("million/compiler");
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    plugins: [million.webpack({ mode: "react", server: true })],
+  });
+};
+```
+</Tab>
+
+<Tab>
+```js filename="vite.config.js"
+import million from "million/compiler";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [million.vite(), react()],
+});
+```
+</Tab>
+
+<Tab>
+```js filename="vite.config.js"
+import { unstable_vitePlugin as remix } from "@remix-run/dev";
+import million from "million/compiler";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [million.vite(), remix()],
+});
+```
+</Tab>
+
+<Tab>
+<Callout type="warning">
+  If you are using a [Create React App (CRA)](https://create-react-app.dev/) Setup, you will need to [configure Craco](https://craco.js.org/docs/getting-started/) before proceeding.
+</Callout>
+```js filename="craco.config.js"
+const million = require("million/compiler");
+module.exports = {
+  webpack: {
+    plugins: { add: [million.webpack()] },
+  },
+};
+```
+</Tab>
+
+<Tab>
+```js filename="webpack.config.js"
+const million = require("million/compiler");
+module.exports = {
+  plugins: [million.webpack()],
+};
+```
+</Tab>
+
+<Tab>
+```js filename="rollup.config.js"
+import million from "million/compiler";
+
+export default {
+  plugins: [million.rollup()],
+};
+```
+</Tab>
+
+</Tabs>
+
+</Steps>
+
+</Tab>
+
+</Tabs>

--- a/website/pages/docs/internals/_meta.fr.json
+++ b/website/pages/docs/internals/_meta.fr.json
@@ -1,0 +1,8 @@
+{
+  "block": "block()",
+  "mount": "mount()",
+  "patch": "patch()",
+  "map-array": "mapArray()",
+  "render-to-template": "renderToTemplate()",
+  "string-to-dom": "stringToDOM()"
+}

--- a/website/pages/docs/manual-mode/_meta.fr.json
+++ b/website/pages/docs/manual-mode/_meta.fr.json
@@ -1,0 +1,6 @@
+{
+  "block": "block()",
+  "manual-mode": "Tutoriel du Mode Manuel",
+  "for": "<For>",
+  "virtualization": "Virtualisation"
+}

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -8,6 +8,11 @@ import packageJson from '../package.json' assert { type: 'json' };
 import { ExtraContent } from './components/extra-content';
 
 const config: DocsThemeConfig = {
+  i18n: [
+  { locale: 'en', text: 'English' },
+  { locale: 'es', text: 'Spanish' },
+  { locale: 'de', text: 'Deutsch' },
+],
   logo: () => {
     return (
       <span>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Added minimal configs for internationalization (i18n) following [Nextra's Documentation](https://nextra.site/docs/guide/i18n)
- Added `_meta` configs for `fr` docs (typically creating `_meta.fr.json` where necessary)
- Translate few headings for `fr` docs files to test `fr` i18n (typically creating `filename.fr.mdx` from `filename.mdx` and translating first headings in fr)

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
