### PR TITLE
website: dev mode to run without liveblock api key

### DIFF
--- a/website/liveblocks.config.ts
+++ b/website/liveblocks.config.ts
@@ -2,10 +2,18 @@ import { createClient } from '@liveblocks/client';
 import { createRoomContext } from '@liveblocks/react';
 import type { JsonObject } from '@liveblocks/client';
 
+const isDevelopment: boolean = process.env.NODE_ENV === 'development';
+
 const client = createClient({
   throttle: 16,
-  publicApiKey: process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!,
+  publicApiKey: isDevelopment
+    ? 'pk_mock-api-key'
+    : process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!,
 });
+if (isDevelopment) {
+  // eslint-disable-next-line no-console
+  console.warn('Development mode: using mock API key');
+}
 interface Presence extends JsonObject {
   cursor: { x: number; y: number } | null;
 }


### PR DESCRIPTION
This PR resolves #867 allowing website to run locally in dev mode without creating a liveblocks account.

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
