### PR TITLE
fix: nextjs hmr on error

### DIFF
--- a/packages/compiler/plugin.ts
+++ b/packages/compiler/plugin.ts
@@ -148,8 +148,9 @@ export const unplugin = createUnplugin((options: Options = {}, meta) => {
           code: result.code || '',
           map: result.map,
         };
-      } catch (_err) {
-        return null;
+      } catch (err) {
+        console.error(err);
+        return { code: '' };
       }
     },
     vite: {


### PR DESCRIPTION
Resolves #878 

Now we return an empty file so we do not break the cycle for next updates. This might not be the ideal solution since I'm not as expert as @lxsmnsyc on the compiler, but it worked.