### PR TITLE
fix: broken `block` link

### DIFF
--- a/website/pages/blog/behind-the-block.en-US.mdx
+++ b/website/pages/blog/behind-the-block.en-US.mdx
@@ -22,7 +22,7 @@ import { CarbonAds } from '../../components/ad';
 
 ---
 
-If you've used Million.js for a while, you've probably heard of the [`block(){:jsx}`](/docs/quickstart) function.
+If you've used Million.js for a while, you've probably heard of the [`block(){:jsx}`](/docs/manual-mode/block) function.
 
 ```jsx {8}
 function MyComponent() {

--- a/website/pages/blog/behind-the-block.es-ES.mdx
+++ b/website/pages/blog/behind-the-block.es-ES.mdx
@@ -21,7 +21,7 @@ import { CarbonAds } from '../../components/ad';
 
 ---
 
-Si has usado Million.js por un tiempo, probablemente hayas escuchado de la función [`block(){:jsx}`](/docs/quickstart).
+Si has usado Million.js por un tiempo, probablemente hayas escuchado de la función [`block(){:jsx}`](/docs/manual-mode/block).
 
 ```jsx {8}
 function MyComponent() {

--- a/website/pages/blog/behind-the-block.fr-FR.mdx
+++ b/website/pages/blog/behind-the-block.fr-FR.mdx
@@ -21,7 +21,7 @@ import { CarbonAds } from '../../components/ad';
 
 ---
 
-Si vous utilisez Million.js depuis un certain temps, vous avez probablement entendu parler de la fonction [`block(){:jsx}`](/docs/quickstart).
+Si vous utilisez Million.js depuis un certain temps, vous avez probablement entendu parler de la fonction [`block(){:jsx}`](/docs/manual-mode/block).
 
 ```jsx
 function MyComponent() {

--- a/website/pages/blog/behind-the-block.zh-CN.mdx
+++ b/website/pages/blog/behind-the-block.zh-CN.mdx
@@ -22,7 +22,7 @@ import { CarbonAds } from '../../components/ad';
 
 ---
 
-If you've used Million.js for a while, you've probably heard of the [`block(){:jsx}`](/docs/quickstart) function.
+If you've used Million.js for a while, you've probably heard of the [`block(){:jsx}`](/docs/manual-mode/block) function.
 
 ```jsx {8}
 function MyComponent() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I was reading the docs and noticed that this link was outdated.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
