### PR TITLE
fix: remix spa

### DIFF
--- a/packages/react-server/index.ts
+++ b/packages/react-server/index.ts
@@ -232,7 +232,7 @@ export const createSSRBoundary = <P extends MillionProps>(
       }
     : {
         dangerouslySetInnerHTML: {
-          __html: document.getElementById(id)!.innerHTML,
+          __html: document.getElementById(id)?.innerHTML || "",
         },
       };
   if (ssrElementsMap.has(id)) {


### PR DESCRIPTION
Resolves #987 

I don't understand how remix spa behaves under the hood since vite is informing us that it's a server build, but still, it's not getting SSRed.

What I did here is just not throwing error when there's no ssr content.