### PR TITLE
fix: `log` compiler option

### DIFF
--- a/packages/compiler/auto.ts
+++ b/packages/compiler/auto.ts
@@ -205,12 +205,11 @@ function shouldTransform(
       : 0.1;
 
   if (improvement <= threshold) return false;
-  if (!ctx.options.log || ctx.options.log === 'info') {
+  if (ctx.options.log === true || ctx.options.log === 'info') {
     logImprovement(
       name,
       improvement,
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      !ctx.options.log || ctx.options.log === 'info',
       ctx.options.telemetry,
     );
   }

--- a/packages/compiler/plugin.ts
+++ b/packages/compiler/plugin.ts
@@ -100,6 +100,10 @@ export interface Options extends Omit<CompilerOptions, 'telemetry'> {
 
 // eslint-disable-next-line @typescript-eslint/default-param-last
 export const unplugin = createUnplugin((options: Options = {}, meta) => {
+  if (!options.log) {
+    options.log = true;
+  }
+
   const filter = createFilter(
     options.filter?.include || DEFAULT_INCLUDE,
     options.filter?.exclude || DEFAULT_EXCLUDE,

--- a/packages/compiler/utils/log.ts
+++ b/packages/compiler/utils/log.ts
@@ -114,7 +114,6 @@ export const catchError = (
 export const logImprovement = (
   component: string,
   improvement: number,
-  stdout: boolean,
   telemetry: MillionTelemetry,
 ): void => {
   void telemetry.record({
@@ -125,14 +124,13 @@ export const logImprovement = (
   const improvementFormatted = isFinite(improvement)
     ? (improvement * 100).toFixed(0)
     : '∞';
-  if (stdout) {
-    // eslint-disable-next-line no-console
-    console.log(
-      `${magenta(' ⚡ ')}${yellow(`<${component}>`)} now renders ${green(
-        underline(`~${improvementFormatted}%`),
-      )} faster`,
-    );
-  }
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `${magenta(' ⚡ ')}${yellow(`<${component}>`)} now renders ${green(
+      underline(`~${improvementFormatted}%`),
+    )} faster`,
+  );
 };
 
 export const logIgnore = (component: string): void => {


### PR DESCRIPTION
There was a confusing behavior caused by the strange logic in the compiler logging.
It is possible to turn off the logging only if the `log` option has been set to a truthy value, which is not equal to `'info'`, because of the condition `!ctx.options.log || ctx.options.log === 'info'`.
However, at the same time, the type of the `log` option is either `boolean | 'info' | undefined`, so there is no valid value with type that can turn off the logging.
I think that this PR will make the logic of the `log` option a little clearer.

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
