### PR TITLE
docs: fix missing paragraph in terms of service page

### DIFF
--- a/website/pages/terms.en-US.mdx
+++ b/website/pages/terms.en-US.mdx
@@ -23,8 +23,11 @@ You agree not to use the Software in a manner that:
 
 - Violates any local, state, national, or international law or regulation.
 - Infringes on the rights of others, including but not limited to intellectual property rights.
-- Is harmful, fraudulent, deceptive, threatening, harassing, defamatory, obscene, or otherwise objectionable. ## 4. Intellectual Property
-  All rights, title, and interest in and to the Software (excluding content provided by users) are and will remain the exclusive property of Million Software, Inc. and its licensors.
+- Is harmful, fraudulent, deceptive, threatening, harassing, defamatory, obscene, or otherwise objectionable.
+
+## 4. Intellectual Property
+
+All rights, title, and interest in and to the Software (excluding content provided by users) are and will remain the exclusive property of Million Software, Inc. and its licensors.
 
 ## 5. Termination
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The terms of service page is missing the 4th paragraph due to a typo.

**Status**

- [X] Code changes have been tested against prettier, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
